### PR TITLE
Add README badges and docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # susieR WDL
 
+[![WDL validation](https://github.com/AoU-Multiomics-Analysis/susieR/actions/workflows/wdl-validation.yml/badge.svg)](https://github.com/AoU-Multiomics-Analysis/susieR/actions/workflows/wdl-validation.yml)
+[![Docker Image CI](https://github.com/AoU-Multiomics-Analysis/susieR/actions/workflows/docker-image.yml/badge.svg)](https://github.com/AoU-Multiomics-Analysis/susieR/actions/workflows/docker-image.yml)
+[![Post-analysis Docker Image CI](https://github.com/AoU-Multiomics-Analysis/susieR/actions/workflows/PostAnalysisImage.yml/badge.svg)](https://github.com/AoU-Multiomics-Analysis/susieR/actions/workflows/PostAnalysisImage.yml)
+
 ## Overview
 
 This repository provides WDL workflows and R scripts for running [SusieR](https://github.com/stephenslab/susieR) fine-mapping on Terra. The workflows are designed to work with data tables on Terra and perform Bayesian fine-mapping of QTL signals identified by tensorQTL.
@@ -257,7 +261,7 @@ Automatically builds and pushes Docker images to the GitHub Container Registry (
 
 The fine-mapping image copies the shared helper code from `R/utils/` into `/opt/r/lib`. The post-analysis image only copies `AnnotateSusie.R` and `MergeSusie.R`, which are the scripts called by the aggregate and annotate WDL tasks.
 
-See `docs/workflows.md` for workflow entry points and `docs/docker.md` for Docker image details. Template inputs are available in `examples/inputs/`.
+See `docs/README.md` for the documentation index, including workflow entry points and Docker image details. Template inputs are available in `examples/inputs/`.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Documentation
+
+This directory holds focused notes for using and maintaining the susieR workflows.
+
+| Document | Use |
+|---|---|
+| [`workflows.md`](workflows.md) | WDL entry points, workflow names, and validation guidance. |
+| [`docker.md`](docker.md) | Docker image layout, image names, and build triggers. |
+
+Template WDL input JSONs live in [`../examples/inputs`](../examples/inputs). They use placeholder paths and values that should be replaced before submitting workflows.
+
+For a local repository health check, run:
+
+```bash
+tools/validate_repo.sh
+```


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow badges to the README
- add docs/README.md as a documentation index
- update README docs pointer to the new index

## Validation
- tools/validate_repo.sh