### PR TITLE
Merge AncestrySkew into susieR

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -21,3 +21,6 @@ workflows:
   - subclass: WDL
     primaryDescriptorPath: /workflows/AnnotateSusie.wdl
     name: "AnnotateSusie"
+  - subclass: WDL
+    primaryDescriptorPath: /workflows/ComputeAncestrySkew.wdl
+    name: "ComputeAncestrySkew"

--- a/.github/workflows/PostAnalysisImage.yml
+++ b/.github/workflows/PostAnalysisImage.yml
@@ -8,6 +8,7 @@ on:
       - "containers/PostAnalysis/Dockerfile"
       - "R/scripts/AnnotateSusie.R"
       - "R/scripts/MergeSusie.R"
+      - "R/scripts/ComputeAncestrySkew.R"
   pull_request:
     branches: [ "main" ]
     paths:
@@ -15,6 +16,7 @@ on:
       - "containers/PostAnalysis/Dockerfile"
       - "R/scripts/AnnotateSusie.R"
       - "R/scripts/MergeSusie.R"
+      - "R/scripts/ComputeAncestrySkew.R"
 
 jobs:
   build_and_push:

--- a/.github/workflows/wdl-validation.yml
+++ b/.github/workflows/wdl-validation.yml
@@ -30,6 +30,7 @@ jobs:
           miniwdl check AggregateSusie.wdl
           miniwdl check AggregateSusieTask.wdl
           miniwdl check AnnotateSusie.wdl
+          miniwdl check ComputeAncestrySkew.wdl
           miniwdl check ComputeR2Susie.wdl
           miniwdl check prepInputsSusieR.wdl
           miniwdl check susieR.wdl

--- a/R/scripts/ComputeAncestrySkew.R
+++ b/R/scripts/ComputeAncestrySkew.R
@@ -1,0 +1,316 @@
+library(tidyverse)
+library(data.table)
+library(optparse)
+
+option_list <- list(
+    optparse::make_option(c("--AnnotationData"), type = "character", default = NULL,
+                        help = "Annotation data for variants containing ancestry specific AC/AN and cohort level AC/AN", metavar = "type"),
+    optparse::make_option(c("--OutputPrefix"), type = "character", default = NULL,
+                        help = "Output file name prefix", metavar = "type"),
+    optparse::make_option(c("--PipThreshold"), type = "double", default = 0.9,
+                        help = "Minimum PIP threshold used to select variants [default %default]", metavar = "number"),
+    optparse::make_option(c("--AdmixedSubpops"), type = "character", default = "oth",
+                        help = "Comma-separated GVS subpopulation labels to remove for the no-admixed skew calculation [default %default]", metavar = "string"),
+    optparse::make_option(c("--KeepInputColumns"), action = "store_true", default = FALSE,
+                        help = "Keep all input annotation columns and append ancestry skew columns [default %default]")
+)
+
+opt <- optparse::parse_args(optparse::OptionParser(option_list = option_list))
+
+if (is.null(opt$AnnotationData)) {
+    stop("--AnnotationData is required", call. = FALSE)
+}
+if (is.null(opt$OutputPrefix)) {
+    stop("--OutputPrefix is required", call. = FALSE)
+}
+
+AnnotationPath <- opt$AnnotationData
+OutputName <- paste0(opt$OutputPrefix, ".AncestrySkew.tsv.gz")
+PipThreshold <- opt$PipThreshold
+AdmixedSubpops <- opt$AdmixedSubpops %>%
+    str_split(",", simplify = FALSE) %>%
+    unlist() %>%
+    str_trim() %>%
+    str_to_lower()
+AdmixedSubpops <- AdmixedSubpops[AdmixedSubpops != ""]
+KeepInputColumns <- opt$KeepInputColumns
+
+required_columns <- c("variant", "pip", "gvs_all_ac", "gvs_all_an")
+
+# Convert allele frequency to minor allele frequency before choosing the max
+# subpopulation. This fixes older annotations where max subpop was based on AF.
+maf <- function(af) {
+    pmin(af, 1 - af)
+}
+
+missing_columns <- function(df, cols) {
+    setdiff(cols, names(df))
+}
+
+is_gzip_file <- function(path) {
+    con <- file(path, "rb")
+    on.exit(close(con))
+    magic <- readBin(con, what = "raw", n = 2)
+    length(magic) == 2 && identical(as.integer(magic), c(0x1f, 0x8b))
+}
+
+read_annotation <- function(path) {
+    if (is_gzip_file(path)) {
+        return(fread(cmd = paste("gzip -dc", shQuote(path))))
+    }
+    fread(path)
+}
+
+require_columns <- function(df, cols, context) {
+    missing <- missing_columns(df, cols)
+    if (length(missing) > 0) {
+        stop(
+            paste0(context, " requires missing column(s): ", paste(missing, collapse = ", ")),
+            call. = FALSE
+        )
+    }
+}
+
+get_subpop_from_af_col <- function(col) {
+    col %>%
+        str_remove("^gvs_") %>%
+        str_remove("_af$")
+}
+
+choose_max_subpop <- function(df, subpops, prefix) {
+    maf_cols <- paste0("gvs_", subpops, "_maf")
+    max_maf_col <- paste0(prefix, "_max_maf")
+    max_subpop_col <- paste0(prefix, "_max_subpop")
+
+    df_with_ids <- df %>%
+        select(-any_of(c(max_subpop_col, max_maf_col))) %>%
+        mutate(.row_id = row_number())
+
+    max_subpop_by_row <- df_with_ids %>%
+        select(.row_id, all_of(maf_cols)) %>%
+        pivot_longer(
+            cols = all_of(maf_cols),
+            names_to = "maf_column",
+            values_to = max_maf_col
+        ) %>%
+        mutate(!!max_subpop_col := get_subpop_from_af_col(str_remove(maf_column, "_maf$"))) %>%
+        filter(!is.na(.data[[max_maf_col]])) %>%
+        slice_max(
+            order_by = .data[[max_maf_col]],
+            n = 1,
+            with_ties = FALSE,
+            by = .row_id
+        ) %>%
+        select(.row_id, all_of(c(max_subpop_col, max_maf_col)))
+
+    df_with_ids %>%
+        left_join(max_subpop_by_row, by = ".row_id") %>%
+        select(-.row_id)
+}
+
+add_max_counts <- function(df, prefix) {
+    max_subpop_col <- paste0(prefix, "_max_subpop")
+    max_ac_col <- paste0(prefix, "_max_ac")
+    max_an_col <- paste0(prefix, "_max_an")
+    df_without_existing <- df %>%
+        select(-any_of(c(max_ac_col, max_an_col)))
+    count_cols <- names(df_without_existing) %>% keep(~ str_detect(.x, "^gvs_[^_]+_(ac|an)$"))
+
+    df_with_ids <- df_without_existing %>%
+        mutate(.row_id = row_number()) %>%
+        select(.row_id, all_of(max_subpop_col), all_of(count_cols))
+
+    max_counts_by_row <- df_with_ids %>%
+        pivot_longer(
+            cols = all_of(count_cols),
+            names_to = c("gvs_prefix", "subpop", ".value"),
+            names_pattern = "^(gvs)_([^_]+)_(ac|an)$"
+        ) %>%
+        filter(subpop == .data[[max_subpop_col]]) %>%
+        transmute(.row_id, !!max_ac_col := ac, !!max_an_col := an)
+
+    df_without_existing %>%
+        mutate(.row_id = row_number()) %>%
+        left_join(max_counts_by_row, by = ".row_id") %>%
+        select(-.row_id)
+}
+
+add_background_counts <- function(df, prefix, all_ac_col, all_an_col) {
+    max_ac_col <- paste0(prefix, "_max_ac")
+    max_an_col <- paste0(prefix, "_max_an")
+    bg_ac_col <- paste0(prefix, "_background_ac")
+    bg_an_col <- paste0(prefix, "_background_an")
+
+    df %>%
+        mutate(
+            !!bg_ac_col := .data[[all_ac_col]] - .data[[max_ac_col]],
+            !!bg_an_col := .data[[all_an_col]] - .data[[max_an_col]]
+        )
+}
+
+run_fisher <- function(df, prefix) {
+    max_ac_col <- paste0(prefix, "_max_ac")
+    max_an_col <- paste0(prefix, "_max_an")
+    bg_ac_col <- paste0(prefix, "_background_ac")
+    bg_an_col <- paste0(prefix, "_background_an")
+    odds_col <- paste0(prefix, "_odds_ratio")
+    p_col <- paste0(prefix, "_p_value")
+
+    fisher_result <- function(max_ac, max_an, background_ac, background_an) {
+        values <- c(max_ac, max_an, background_ac, background_an)
+
+        if (any(is.na(values)) || any(values < 0)) {
+            return(tibble(odds_ratio = NA_real_, p_value = NA_real_))
+        }
+
+        test <- fisher.test(matrix(values, nrow = 2, byrow = TRUE))
+        tibble(odds_ratio = unname(test$estimate), p_value = test$p.value)
+    }
+
+    df %>%
+        mutate(
+            .fisher = pmap(
+                list(
+                    .data[[max_ac_col]],
+                    .data[[max_an_col]],
+                    .data[[bg_ac_col]],
+                    .data[[bg_an_col]]
+                ),
+                fisher_result
+            )
+        ) %>%
+        unnest_wider(.fisher) %>%
+        rename(!!odds_col := odds_ratio, !!p_col := p_value)
+}
+
+####### LOAD DATA ########
+AnnotationDf <- read_annotation(AnnotationPath)
+
+require_columns(AnnotationDf, required_columns, "Ancestry skew")
+
+af_cols <- names(AnnotationDf) %>%
+    keep(~ str_detect(.x, "^gvs_[^_]+_af$") && .x != "gvs_all_af" && .x != "gvs_max_af")
+
+if (length(af_cols) == 0) {
+    stop("No GVS subpopulation allele frequency columns found. Expected columns like gvs_afr_af.", call. = FALSE)
+}
+
+subpops <- map_chr(af_cols, get_subpop_from_af_col)
+admixed_subpops <- intersect(AdmixedSubpops, subpops)
+nonadmixed_subpops <- setdiff(subpops, admixed_subpops)
+
+if (length(admixed_subpops) == 0) {
+    stop(
+        paste0(
+            "None of the requested admixed subpops were found in GVS AF columns: ",
+            paste(AdmixedSubpops, collapse = ", ")
+        ),
+        call. = FALSE
+    )
+}
+if (length(nonadmixed_subpops) == 0) {
+    stop("No non-admixed subpopulations remain after applying --AdmixedSubpops.", call. = FALSE)
+}
+
+count_cols <- c(paste0("gvs_", subpops, "_ac"), paste0("gvs_", subpops, "_an"))
+require_columns(
+    AnnotationDf,
+    count_cols,
+    paste0(
+        "MAF-based max subpopulation AC/AN lookup. The attached annotation contains AF columns, ",
+        "but exact skew needs matching per-subpopulation AC/AN columns"
+    )
+)
+
+numeric_cols <- names(AnnotationDf) %>%
+    keep(~ str_detect(.x, "^gvs_.*_(ac|an|af)$") || .x %in% c("pip"))
+numeric_cols <- unique(numeric_cols)
+
+removed_count_cols <- unlist(map(
+    admixed_subpops,
+    ~ c(paste0("gvs_no_admixed_removed_", .x, "_ac"), paste0("gvs_no_admixed_removed_", .x, "_an"))
+))
+
+OutputColumns <- c(
+    "variant", "pip",
+    "gvs_max_subpop", "gvs_max_maf", "gvs_max_ac", "gvs_max_an",
+    "gvs_background_ac", "gvs_background_an", "gvs_odds_ratio", "gvs_p_value",
+    "gvs_no_admixed_all_ac", "gvs_no_admixed_all_an",
+    "gvs_no_admixed_max_subpop", "gvs_no_admixed_max_maf",
+    "gvs_no_admixed_max_ac", "gvs_no_admixed_max_an",
+    "gvs_no_admixed_background_ac", "gvs_no_admixed_background_an",
+    "gvs_no_admixed_odds_ratio", "gvs_no_admixed_p_value",
+    removed_count_cols
+)
+
+# Keep only variants at or above the requested PIP threshold, then create MAF
+# columns for every GVS ancestry-specific AF column.
+SkewInput <- AnnotationDf %>%
+    mutate(across(all_of(numeric_cols), ~ as.numeric(.))) %>%
+    filter(pip >= PipThreshold) %>%
+    mutate(across(all_of(af_cols), maf, .names = "{.col}_maf"))
+
+maf_col_names <- paste0(af_cols, "_maf")
+names(SkewInput)[match(maf_col_names, names(SkewInput))] <- paste0("gvs_", subpops, "_maf")
+
+if (nrow(SkewInput) == 0) {
+    warning("No variants passed the PIP threshold; writing an empty output.")
+    empty_columns <- OutputColumns
+    if (KeepInputColumns) {
+        empty_columns <- c(names(AnnotationDf), setdiff(OutputColumns, names(AnnotationDf)))
+    }
+    empty_output <- as_tibble(setNames(replicate(length(empty_columns), logical(0), simplify = FALSE), empty_columns))
+    empty_output %>% write_tsv(OutputName)
+    quit(save = "no", status = 0)
+}
+
+# Round 1: ancestry skew with admixed samples included.
+#
+# This recomputes the max GVS subpopulation from MAF, looks up that
+# subpopulation's AC/AN, builds the all-other-background counts, and runs the
+# first Fisher test.
+SkewInput <- SkewInput %>%
+    choose_max_subpop(subpops, "gvs") %>%
+    add_max_counts("gvs") %>%
+    add_background_counts("gvs", "gvs_all_ac", "gvs_all_an") %>%
+    run_fisher("gvs")
+
+# Store the admixed AC/AN values that will be subtracted so the output is
+# auditable. By default this is the GVS `oth` subpopulation.
+SkewInput <- reduce(
+    admixed_subpops,
+    .init = SkewInput,
+    .f = function(df, subpop) {
+        df %>%
+            mutate(
+                !!paste0("gvs_no_admixed_removed_", subpop, "_ac") := .data[[paste0("gvs_", subpop, "_ac")]],
+                !!paste0("gvs_no_admixed_removed_", subpop, "_an") := .data[[paste0("gvs_", subpop, "_an")]]
+            )
+    }
+)
+
+# Round 2: ancestry skew after admixed samples are removed.
+#
+# The admixed AC/AN are subtracted from cohort-level AC/AN first. Then the max
+# subpopulation is recalculated from MAF using only the non-admixed
+# subpopulations before running the second Fisher test.
+SkewInput <- SkewInput %>%
+    mutate(
+        gvs_no_admixed_all_ac = gvs_all_ac - rowSums(across(all_of(paste0("gvs_", admixed_subpops, "_ac"))), na.rm = FALSE),
+        gvs_no_admixed_all_an = gvs_all_an - rowSums(across(all_of(paste0("gvs_", admixed_subpops, "_an"))), na.rm = FALSE)
+    ) %>%
+    choose_max_subpop(nonadmixed_subpops, "gvs_no_admixed") %>%
+    add_max_counts("gvs_no_admixed") %>%
+    add_background_counts("gvs_no_admixed", "gvs_no_admixed_all_ac", "gvs_no_admixed_all_an") %>%
+    run_fisher("gvs_no_admixed")
+
+OutputDf <- SkewInput %>%
+    select(all_of(OutputColumns))
+
+if (KeepInputColumns) {
+    OutputDf <- SkewInput %>%
+        select(all_of(names(AnnotationDf)), all_of(setdiff(OutputColumns, names(AnnotationDf))))
+}
+
+OutputDf %>%
+    write_tsv(OutputName)

--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ This repository provides WDL workflows and R scripts for running [susieR](https:
 | [`workflows/ComputeR2Susie.wdl`](workflows/ComputeR2Susie.wdl) | `ComputeR2SusieWorkflow` | Run cross-validation R2 evaluation. |
 | [`workflows/AggregateSusieTask.wdl`](workflows/AggregateSusieTask.wdl) | `AggregateSusieTaskWorkflow` | Merge sharded Susie Parquet outputs. |
 | [`workflows/AnnotateSusie.wdl`](workflows/AnnotateSusie.wdl) | `AnnotateSusieWorkflow` | Annotate a merged Susie TSV. |
+| [`workflows/ComputeAncestrySkew.wdl`](workflows/ComputeAncestrySkew.wdl) | `ComputeAncestrySkew` | Compute ancestry skew for annotated Susie variants. |
 | [`workflows/AggregateSusie.wdl`](workflows/AggregateSusie.wdl) | `AggregateSusieWorkflow` | Run aggregate, annotate, and ancestry skew together. |
 
-## External Dependency
+## Post-Analysis
 
-`AggregateSusie.wdl` imports the canonical ancestry skew workflow from the [AncestrySkew](https://github.com/AoU-Multiomics-Analysis/AncestrySkew) repository over HTTPS. Make ancestry skew workflow changes in that repository rather than duplicating the WDL or R code here.
+The aggregate, annotate, and ancestry skew steps are available as standalone workflows and as one combined `AggregateSusieWorkflow`. Ancestry skew now lives in this repository and is validated with the rest of the susieR WDLs.
 
 ## Local Checks
 
@@ -59,4 +60,4 @@ tools/validate_repo.sh
 Rscript tools/lint_r.R
 ```
 
-The WDL validation resolves remote imports through `raw.githubusercontent.com`, so it requires network access.
+The WDL validation checks all workflow descriptors in `workflows/`.

--- a/containers/PostAnalysis/Dockerfile
+++ b/containers/PostAnalysis/Dockerfile
@@ -32,6 +32,6 @@ RUN find ${HOME}/.pixi/envs/r-base/bin -name '*bioconductor-*-post-link.sh' | \
     #conda-forge::r-bedr \
     #bioconda::tabix
 
-COPY R/scripts/AnnotateSusie.R R/scripts/MergeSusie.R /
+COPY R/scripts/AnnotateSusie.R R/scripts/MergeSusie.R R/scripts/ComputeAncestrySkew.R /
 
 CMD ["bash"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This directory holds focused notes for using and maintaining the susieR workflow
 
 | Document | Use |
 |---|---|
-| [`workflows.md`](workflows.md) | WDL entry points, workflow names, inputs, outputs, and validation guidance. |
+| [`workflows.md`](workflows.md) | WDL entry points, workflow names, inputs, outputs, ancestry skew, and validation guidance. |
 | [`scripts.md`](scripts.md) | R entrypoint scripts, expected inputs, and generated outputs. |
 | [`docker.md`](docker.md) | Docker image layout, image names, and CI rebuild triggers. |
 | [`inputs.md`](inputs.md) | Common WDL inputs and optional fine-mapping controls. |

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -5,7 +5,7 @@ This repository builds two Docker images from the `containers/` directory.
 | Dockerfile | Image | Contains |
 |---|---|---|
 | `containers/SusieR/Dockerfile` | `ghcr.io/aou-multiomics-analysis/susier` | Fine-mapping scripts from `R/scripts/` plus shared helpers from `R/utils/`. |
-| `containers/PostAnalysis/Dockerfile` | `ghcr.io/aou-multiomics-analysis/susier/postanalysis` | Post-analysis scripts `AnnotateSusie.R` and `MergeSusie.R`. |
+| `containers/PostAnalysis/Dockerfile` | `ghcr.io/aou-multiomics-analysis/susier/postanalysis` | Post-analysis scripts `AnnotateSusie.R`, `MergeSusie.R`, and `ComputeAncestrySkew.R`. |
 
 The fine-mapping image sets `SUSIER_FUNCTIONS_PATH=/opt/r/lib`, and the R scripts default to that location when sourcing shared helpers.
 
@@ -16,6 +16,6 @@ The Docker workflows build and push images to GitHub Container Registry (`ghcr.i
 | Workflow | Dockerfile | Image | Rebuilds when |
 |---|---|---|---|
 | `.github/workflows/docker-image.yml` | `containers/SusieR/Dockerfile` | `ghcr.io/aou-multiomics-analysis/susier` | Fine-mapping image dependencies, `R/scripts/**`, or `R/utils/**` change. |
-| `.github/workflows/PostAnalysisImage.yml` | `containers/PostAnalysis/Dockerfile` | `ghcr.io/aou-multiomics-analysis/susier/postanalysis` | Post-analysis image dependencies, `R/scripts/AnnotateSusie.R`, or `R/scripts/MergeSusie.R` change. |
+| `.github/workflows/PostAnalysisImage.yml` | `containers/PostAnalysis/Dockerfile` | `ghcr.io/aou-multiomics-analysis/susier/postanalysis` | Post-analysis image dependencies, `R/scripts/AnnotateSusie.R`, `R/scripts/MergeSusie.R`, or `R/scripts/ComputeAncestrySkew.R` change. |
 
-The post-analysis image only copies `AnnotateSusie.R` and `MergeSusie.R`, which are the scripts called by the aggregate and annotate WDL tasks.
+The post-analysis image copies the scripts called by the aggregate, annotate, and ancestry skew WDL tasks.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -70,3 +70,31 @@ Outputs:
 ## `R/scripts/AnnotateSusie.R`
 
 Annotates a merged Susie TSV with external annotation resources used by the post-analysis workflows.
+
+## `R/scripts/ComputeAncestrySkew.R`
+
+Computes ancestry skew for variants in an annotated TSV or gzipped TSV. The script filters variants by PIP, recalculates the GVS max subpopulation from minor allele frequency, and runs Fisher tests comparing the max subpopulation to the remaining cohort.
+
+The script also reports a second ancestry skew calculation with admixed samples removed from the cohort background. By default, the admixed subpopulation is `oth`, but this can be changed with a comma-separated value such as `oth,amr`.
+
+Required annotation columns:
+
+| Column pattern | Description |
+|---|---|
+| `variant` | Variant identifier. |
+| `pip` | Posterior inclusion probability used for filtering. |
+| `gvs_all_ac`, `gvs_all_an` | Cohort-level alternate allele count and allele number. |
+| `gvs_<subpop>_af` | Subpopulation allele frequency columns, such as `gvs_afr_af`, `gvs_amr_af`, and `gvs_eur_af`. |
+| `gvs_<subpop>_ac`, `gvs_<subpop>_an` | Matching subpopulation AC/AN columns for every `gvs_<subpop>_af` column. |
+
+Key command-line arguments:
+
+| Argument | Description |
+|---|---|
+| `--AnnotationData` | Annotated variant table. Plain TSV and gzip-compressed TSV inputs are supported. |
+| `--OutputPrefix` | Output file prefix. |
+| `--PipThreshold` | Minimum PIP threshold used to select variants. Defaults to `0.9`. |
+| `--AdmixedSubpops` | Comma-separated GVS subpopulation labels to remove for the no-admixed skew calculation. Defaults to `oth`. |
+| `--KeepInputColumns` | Keep all input annotation columns and append ancestry skew columns. |
+
+Output: `<OutputPrefix>.AncestrySkew.tsv.gz`.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -10,6 +10,7 @@ The WDL descriptors live in `workflows/`. Each descriptor has a unique workflow 
 | `workflows/ComputeR2Susie.wdl` | `ComputeR2SusieWorkflow` | Run cross-validation R2 evaluation. |
 | `workflows/AggregateSusieTask.wdl` | `AggregateSusieTaskWorkflow` | Merge sharded Susie Parquet outputs. |
 | `workflows/AnnotateSusie.wdl` | `AnnotateSusieWorkflow` | Annotate a merged Susie TSV. |
+| `workflows/ComputeAncestrySkew.wdl` | `ComputeAncestrySkew` | Compute ancestry skew for annotated Susie variants. |
 | `workflows/AggregateSusie.wdl` | `AggregateSusieWorkflow` | Run aggregate, annotate, and ancestry skew together. |
 
 Template input JSONs live in [`../examples/inputs/`](../examples/inputs/). They use placeholder paths and values; replace those with workspace-specific files before submitting.
@@ -88,7 +89,8 @@ The post-fine-mapping workflows are split into standalone WDLs so each step can 
 |---|---|---|
 | `workflows/AggregateSusieTask.wdl` | `AggregateSusieTaskWorkflow` | Localizes sharded Susie Parquet outputs from a FOFN and merges them into one Parquet plus one gzipped TSV. |
 | `workflows/AnnotateSusie.wdl` | `AnnotateSusieWorkflow` | Annotates an existing merged Susie TSV with GENCODE, ENCODE, FANTOM5, gnomAD constraint, phyloP, and VAT data. |
-| `workflows/AggregateSusie.wdl` | `AggregateSusieWorkflow` | Runs aggregate, annotate, and ancestry-skew analysis together by importing the two standalone Susie WDLs plus the AncestrySkew workflow. |
+| `workflows/ComputeAncestrySkew.wdl` | `ComputeAncestrySkew` | Computes ancestry skew on an annotated Susie TSV. |
+| `workflows/AggregateSusie.wdl` | `AggregateSusieWorkflow` | Runs aggregate, annotate, and ancestry-skew analysis together by importing the three standalone post-analysis WDLs. |
 
 ### Aggregate-Only Inputs
 
@@ -124,15 +126,20 @@ Annotate-only output: `AnnotatedSusieTsv`, written as `<OutputPrefix>_SusieMerge
 
 The combined `AggregateSusieWorkflow` keeps the same aggregate and annotation inputs, adds optional ancestry-skew controls (`AncestrySkewVariantsPerShard`, `AncestrySkewPipThreshold`, and `AncestrySkewAdmixedSubpops`), and returns both the ancestry-skew annotated TSV and the annotation-only TSV.
 
-## AncestrySkew Dependency
+### Ancestry Skew Inputs
 
-`AggregateSusie.wdl` imports the canonical ancestry skew workflow directly from the AncestrySkew repository:
+| Input | Type | Default | Description |
+|---|---|---|---|
+| `AnnotationData` | File | required | Annotated variant table. Plain TSV and gzip-compressed TSV inputs are supported. |
+| `OutputFile` | String | required | Name for the aggregated output file, usually ending in `.tsv.gz`. |
+| `VariantsPerShard` | Int | required | Number of input rows per shard. |
+| `PipThreshold` | Float | `0.9` | Variants with `pip >= PipThreshold` are included. |
+| `AdmixedSubpops` | String | `"oth"` | Comma-separated GVS subpopulation labels to remove for the no-admixed skew calculation. |
+| `KeepInputColumns` | Boolean | `false` | Keep all input annotation columns and append ancestry skew columns. |
 
-```wdl
-import "https://raw.githubusercontent.com/AoU-Multiomics-Analysis/AncestrySkew/main/workflows/ComputeAncestrySkew.wdl" as AncestrySkew
-```
+### Ancestry Skew Outputs
 
-Ancestry skew changes should be made in the [AncestrySkew](https://github.com/AoU-Multiomics-Analysis/AncestrySkew) repository. susieR imports that WDL over HTTPS instead of carrying duplicate copies of `ComputeAncestrySkew.wdl` and `ComputeAncestrySkew.R`. This import style works in Terra because Terra resolves WDL imports through `raw.githubusercontent.com`, while GitHub submodule contents are not exposed at raw paths.
+The aggregated output is a gzip-compressed TSV with one row per variant passing the PIP threshold. Key added columns include `gvs_max_subpop`, `gvs_max_maf`, `gvs_odds_ratio`, `gvs_p_value`, `gvs_no_admixed_max_subpop`, `gvs_no_admixed_odds_ratio`, and `gvs_no_admixed_p_value`.
 
 ## Validation
 

--- a/examples/inputs/ComputeAncestrySkew.inputs.json
+++ b/examples/inputs/ComputeAncestrySkew.inputs.json
@@ -1,0 +1,8 @@
+{
+  "ComputeAncestrySkew.AnnotationData": "gs://bucket/path/to/susie_annotated.tsv.gz",
+  "ComputeAncestrySkew.OutputFile": "susie_annotated.ancestry_skew.tsv.gz",
+  "ComputeAncestrySkew.VariantsPerShard": 50000,
+  "ComputeAncestrySkew.PipThreshold": 0.9,
+  "ComputeAncestrySkew.AdmixedSubpops": "oth",
+  "ComputeAncestrySkew.KeepInputColumns": false
+}

--- a/workflows/AggregateSusie.wdl
+++ b/workflows/AggregateSusie.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "AggregateSusieTask.wdl" as AggregateSusieTask
 import "AnnotateSusie.wdl" as AnnotateSusieTask
-import "https://raw.githubusercontent.com/AoU-Multiomics-Analysis/AncestrySkew/main/workflows/ComputeAncestrySkew.wdl" as AncestrySkew
+import "ComputeAncestrySkew.wdl" as AncestrySkew
 
 workflow AggregateSusieWorkflow {
     input {

--- a/workflows/ComputeAncestrySkew.wdl
+++ b/workflows/ComputeAncestrySkew.wdl
@@ -1,0 +1,180 @@
+version 1.0
+
+workflow ComputeAncestrySkew {
+    input {
+        File AnnotationData
+        String OutputFile
+        Int VariantsPerShard
+        Float PipThreshold = 0.9
+        String AdmixedSubpops = "oth"
+        Boolean KeepInputColumns = false
+    }
+    
+    call ShardVariants {
+        input:
+            AnnotationData = AnnotationData,
+            rows_per_shard = VariantsPerShard
+    }
+
+    scatter (shard in ShardVariants.shard_files) {
+        call GetAncestrySkew {
+            input:
+                AnnotationData = shard,
+                PipThreshold = PipThreshold,
+                AdmixedSubpops = AdmixedSubpops,
+                KeepInputColumns = KeepInputColumns
+        }
+    }
+    
+    call AggregateAncestrySkew {
+        input:
+            shard_outputs =  GetAncestrySkew.AncestrySkewOutput,
+            OutputFile = OutputFile
+    }
+    output {
+        File Output = AggregateAncestrySkew.AggregatedOutput
+    }
+}
+
+
+task ShardVariants {
+    input {
+        File AnnotationData
+        Int rows_per_shard
+    }
+    command <<<
+      python3 <<PY
+    import csv
+    import json
+    import os
+    import gzip
+
+    infile = "~{AnnotationData}"
+    rows_per_shard = ~{rows_per_shard}
+
+    os.makedirs("shards", exist_ok=True)
+
+    def is_gzip(path):
+        with open(path, "rb") as probe:
+            return probe.read(2) == b"\x1f\x8b"
+
+    # Open plain TSV or gzip-compressed TSV, even if the suffix is not .gz.
+    if is_gzip(infile):
+        fh = gzip.open(infile, "rt")
+    else:
+        fh = open(infile, "r")
+
+    reader = csv.DictReader(fh, delimiter="\t")
+    header = reader.fieldnames
+    if header is None:
+        raise ValueError("Input file has no header")
+
+    shard_idx = 0
+    rows_in_current_shard = 0
+    out = None
+    writer = None
+    shard_paths = []
+
+    def open_shard(idx):
+        path = f"shards/shard_{idx:04d}.tsv"
+        handle = open(path, "w", newline="")
+        w = csv.DictWriter(handle, fieldnames=header, delimiter="\t")
+        w.writeheader()
+        return path, handle, w
+
+    for row in reader:
+        if writer is None or rows_in_current_shard >= rows_per_shard:
+            if out is not None:
+                out.close()
+            shard_path, out, writer = open_shard(shard_idx)
+            shard_paths.append(shard_path)
+            shard_idx += 1
+            rows_in_current_shard = 0
+
+        writer.writerow(row)
+        rows_in_current_shard += 1
+
+    fh.close()
+
+    if out is not None:
+        out.close()
+
+    with open("shard_manifest.json", "w") as f:
+        json.dump(shard_paths, f)
+    PY
+    >>>    
+    output {
+      Array[File] shard_files = glob("shards/*.tsv")
+      File manifest = "shard_manifest.json"
+    }
+    runtime {
+        docker: "python:3.10"
+        memory: "32G"
+        cpu: 1
+        disks: "local-disk 2500 SSD"
+  }
+}
+
+task GetAncestrySkew {
+    input {
+        File AnnotationData
+        Float PipThreshold
+        String AdmixedSubpops
+        Boolean KeepInputColumns
+    }
+    String shard_base = basename(AnnotationData, ".tsv")
+
+    command <<< 
+
+    Rscript /ComputeAncestrySkew.R \
+       --AnnotationData ~{AnnotationData} \
+       --OutputPrefix ~{shard_base} \
+       --PipThreshold ~{PipThreshold} \
+       --AdmixedSubpops "~{AdmixedSubpops}" \
+       ~{if KeepInputColumns then "--KeepInputColumns" else ""}
+    >>>
+    
+    runtime {
+        docker: "ghcr.io/aou-multiomics-analysis/susier/postanalysis:main"
+        memory: "96G"
+        cpu: 2
+        disks: "local-disk 2500 SSD"
+    }
+    
+    output {
+        File AncestrySkewOutput = shard_base + ".AncestrySkew.tsv.gz" 
+    }
+}
+
+task AggregateAncestrySkew {
+
+    input {
+        Array[File] shard_outputs
+        String OutputFile
+    }
+
+    command <<<
+    set -euo pipefail
+
+    first=1
+
+    for f in ~{sep=' ' shard_outputs}; do
+        if [ $first -eq 1 ]; then
+            zcat "$f"
+            first=0
+        else
+            zcat "$f" | tail -n +2
+        fi
+    done | gzip > "~{OutputFile}"
+    >>>
+    runtime {
+        docker: "ghcr.io/aou-multiomics-analysis/susier/postanalysis:main"
+        memory: "32G"
+        cpu: 2
+        disks: "local-disk 2500 SSD"
+    }
+    
+    output {
+        File AggregatedOutput = OutputFile
+    }
+}


### PR DESCRIPTION
## Summary
- import ComputeAncestrySkew WDL and R script into the susieR repo
- switch AggregateSusie to a local ComputeAncestrySkew import
- run AncestrySkew tasks on the existing post-analysis image and copy ComputeAncestrySkew.R into that image
- add Dockstore, CI, docs, and example input coverage for the standalone ancestry skew workflow

## Dependency scan
- ComputeAncestrySkew.R imports tidyverse, data.table, and optparse
- those packages are already installed by containers/PostAnalysis/Dockerfile
- PostAnalysisImage.yml now rebuilds when ComputeAncestrySkew.R changes

## Checks
- tools/validate_repo.sh
- R_LIBS_USER=/tmp/susier-r-lib Rscript tools/lint_r.R