### PR TITLE
Fix ComputeAncestrySkew script lookup

### DIFF
--- a/containers/PostAnalysis/Dockerfile
+++ b/containers/PostAnalysis/Dockerfile
@@ -32,6 +32,10 @@ RUN find ${HOME}/.pixi/envs/r-base/bin -name '*bioconductor-*-post-link.sh' | \
     #conda-forge::r-bedr \
     #bioconda::tabix
 
-COPY R/scripts/AnnotateSusie.R R/scripts/MergeSusie.R R/scripts/ComputeAncestrySkew.R /
+RUN mkdir -p /opt/r/scripts
+COPY R/scripts/AnnotateSusie.R R/scripts/MergeSusie.R R/scripts/ComputeAncestrySkew.R /opt/r/scripts/
+RUN ln -s /opt/r/scripts/AnnotateSusie.R /AnnotateSusie.R && \
+    ln -s /opt/r/scripts/MergeSusie.R /MergeSusie.R && \
+    ln -s /opt/r/scripts/ComputeAncestrySkew.R /ComputeAncestrySkew.R
 
 CMD ["bash"]

--- a/workflows/ComputeAncestrySkew.wdl
+++ b/workflows/ComputeAncestrySkew.wdl
@@ -124,9 +124,23 @@ task GetAncestrySkew {
     }
     String shard_base = basename(AnnotationData, ".tsv")
 
-    command <<< 
+    command <<<
+    set -euo pipefail
 
-    Rscript /ComputeAncestrySkew.R \
+    SCRIPT_PATH=""
+    for candidate in /opt/r/scripts/ComputeAncestrySkew.R /tmp/ComputeAncestrySkew.R /ComputeAncestrySkew.R; do
+        if [ -f "$candidate" ]; then
+            SCRIPT_PATH="$candidate"
+            break
+        fi
+    done
+
+    if [ -z "$SCRIPT_PATH" ]; then
+        echo "Could not find ComputeAncestrySkew.R in /opt/r/scripts, /tmp, or /" >&2
+        exit 1
+    fi
+
+    Rscript "$SCRIPT_PATH" \
        --AnnotationData ~{AnnotationData} \
        --OutputPrefix ~{shard_base} \
        --PipThreshold ~{PipThreshold} \


### PR DESCRIPTION
## Summary
- install post-analysis scripts into /opt/r/scripts in the Docker image
- keep root-level symlinks for existing AnnotateSusie and MergeSusie WDL commands
- make ComputeAncestrySkew resolve its script from /opt/r/scripts, /tmp, or / before running Rscript

## Why
Terra reported: Fatal error: cannot open file '/ComputeAncestrySkew.R': No such file or directory. This makes the script lookup robust across image/runtime path differences while preserving current task paths.

## Checks
- tools/validate_repo.sh
- R_LIBS_USER=/tmp/susier-r-lib Rscript tools/lint_r.R
- git diff --check