### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "deps"
+      include: "scope"


### PR DESCRIPTION
## Summary
- add Dependabot configuration for weekly GitHub Actions updates
- label Dependabot PRs with dependencies and github-actions
- use a deps commit-message prefix

## Checks
- ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'
- tools/validate_repo.sh
- git diff --check