### PR TITLE
Add Docker image smoke tests

### DIFF
--- a/.github/workflows/PostAnalysisImage.yml
+++ b/.github/workflows/PostAnalysisImage.yml
@@ -1,6 +1,7 @@
 name: Post-analysis Docker Image CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
     paths:
@@ -42,7 +43,33 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}/postanalysis
 
+      - name: Build docker image for smoke tests
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: containers/PostAnalysis/Dockerfile
+          load: true
+          tags: susier-postanalysis:smoke-test
+
+      - name: Smoke test docker image
+        run: |
+          set -euo pipefail
+          docker run --rm susier-postanalysis:smoke-test test -f /opt/r/scripts/MergeSusie.R
+          docker run --rm susier-postanalysis:smoke-test test -f /opt/r/scripts/AnnotateSusie.R
+          docker run --rm susier-postanalysis:smoke-test test -f /opt/r/scripts/ComputeAncestrySkew.R
+          docker run --rm susier-postanalysis:smoke-test test -f /MergeSusie.R
+          docker run --rm susier-postanalysis:smoke-test test -f /AnnotateSusie.R
+          docker run --rm susier-postanalysis:smoke-test test -f /ComputeAncestrySkew.R
+          docker run --rm susier-postanalysis:smoke-test test -f /tmp/MergeSusie.R
+          docker run --rm susier-postanalysis:smoke-test test -f /tmp/AnnotateSusie.R
+          docker run --rm susier-postanalysis:smoke-test test -f /tmp/ComputeAncestrySkew.R
+          docker run --rm susier-postanalysis:smoke-test Rscript -e 'library(tidyverse); library(data.table); library(arrow); library(optparse); library(rtracklayer); library(plyranges); library(bedr)'
+          docker run --rm susier-postanalysis:smoke-test Rscript /opt/r/scripts/MergeSusie.R --help
+          docker run --rm susier-postanalysis:smoke-test Rscript /opt/r/scripts/AnnotateSusie.R --help
+          docker run --rm susier-postanalysis:smoke-test Rscript /opt/r/scripts/ComputeAncestrySkew.R --help
+
       - name: Build and push docker containers
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v7
         with:
           context: .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,14 +7,18 @@ on:
     paths:
       - ".github/workflows/docker-image.yml"
       - "containers/SusieR/Dockerfile"
-      - "R/scripts/**"
+      - "R/scripts/susie.R"
+      - "R/scripts/ComputeR2Susie.R"
+      - "R/scripts/PrepSusieCVPCs.R"
       - "R/utils/**"
   pull_request:
     branches: [ "main" ]
     paths:
       - ".github/workflows/docker-image.yml"
       - "containers/SusieR/Dockerfile"
-      - "R/scripts/**"
+      - "R/scripts/susie.R"
+      - "R/scripts/ComputeR2Susie.R"
+      - "R/scripts/PrepSusieCVPCs.R"
       - "R/utils/**"
 
 jobs:
@@ -41,7 +45,30 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
 
+      - name: Build docker image for smoke tests
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: containers/SusieR/Dockerfile
+          load: true
+          tags: susier:smoke-test
+
+      - name: Smoke test docker image
+        run: |
+          set -euo pipefail
+          docker run --rm susier:smoke-test test -f /opt/r/scripts/susie.R
+          docker run --rm susier:smoke-test test -f /opt/r/scripts/ComputeR2Susie.R
+          docker run --rm susier:smoke-test test -f /opt/r/scripts/PrepSusieCVPCs.R
+          docker run --rm susier:smoke-test test -f /tmp/susie.R
+          docker run --rm susier:smoke-test test -f /tmp/ComputeR2Susie.R
+          docker run --rm susier:smoke-test test -f /tmp/PrepSusieCVPCs.R
+          docker run --rm susier:smoke-test Rscript -e 'library(devtools); library(susieR); library(stringr); library(optparse); library(Rsamtools); library(readr); library(tidyr); library(dplyr); library(arrow); library(Rfast); library(edgeR); library(eQTLUtils)'
+          docker run --rm susier:smoke-test Rscript /opt/r/scripts/susie.R --help
+          docker run --rm susier:smoke-test Rscript /opt/r/scripts/ComputeR2Susie.R --help
+          docker run --rm susier:smoke-test Rscript -e 'parse(file = "/opt/r/scripts/PrepSusieCVPCs.R")'
+
       - name: Build and push docker containers
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v7
         with:
           context: .

--- a/containers/PostAnalysis/Dockerfile
+++ b/containers/PostAnalysis/Dockerfile
@@ -36,6 +36,9 @@ RUN mkdir -p /opt/r/scripts
 COPY R/scripts/AnnotateSusie.R R/scripts/MergeSusie.R R/scripts/ComputeAncestrySkew.R /opt/r/scripts/
 RUN ln -s /opt/r/scripts/AnnotateSusie.R /AnnotateSusie.R && \
     ln -s /opt/r/scripts/MergeSusie.R /MergeSusie.R && \
-    ln -s /opt/r/scripts/ComputeAncestrySkew.R /ComputeAncestrySkew.R
+    ln -s /opt/r/scripts/ComputeAncestrySkew.R /ComputeAncestrySkew.R && \
+    ln -s /opt/r/scripts/AnnotateSusie.R /tmp/AnnotateSusie.R && \
+    ln -s /opt/r/scripts/MergeSusie.R /tmp/MergeSusie.R && \
+    ln -s /opt/r/scripts/ComputeAncestrySkew.R /tmp/ComputeAncestrySkew.R
 
 CMD ["bash"]

--- a/containers/SusieR/Dockerfile
+++ b/containers/SusieR/Dockerfile
@@ -24,6 +24,7 @@ RUN micromamba install -y -n base -c conda-forge -c bioconda \
     conda-forge::r-arrow \
     bioconda::bioconductor-genomicranges=1.58.0 \
     bioconda::bioconductor-rsamtools \
+    bioconda::bioconductor-edger \
     bioconda::bioconductor-summarizedexperiment \
     conda-forge::r-susier \
     conda-forge::r-igraph \
@@ -41,7 +42,14 @@ RUN micromamba install -y -n base -c conda-forge -c bioconda \
 RUN R -e "remotes::install_github('kauralasoo/eQTLUtils')"
 ENV SUSIER_FUNCTIONS_PATH=/opt/r/lib
 COPY R/utils/*  /opt/r/lib/
-COPY R/scripts/*  .
+RUN mkdir -p /opt/r/scripts
+COPY R/scripts/susie.R R/scripts/ComputeR2Susie.R R/scripts/PrepSusieCVPCs.R /opt/r/scripts/
+RUN ln -s /opt/r/scripts/susie.R /susie.R && \
+    ln -s /opt/r/scripts/ComputeR2Susie.R /ComputeR2Susie.R && \
+    ln -s /opt/r/scripts/PrepSusieCVPCs.R /PrepSusieCVPCs.R && \
+    ln -s /opt/r/scripts/susie.R /tmp/susie.R && \
+    ln -s /opt/r/scripts/ComputeR2Susie.R /tmp/ComputeR2Susie.R && \
+    ln -s /opt/r/scripts/PrepSusieCVPCs.R /tmp/PrepSusieCVPCs.R
 
 
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,10 +4,12 @@ This repository builds two Docker images from the `containers/` directory.
 
 | Dockerfile | Image | Contains |
 |---|---|---|
-| `containers/SusieR/Dockerfile` | `ghcr.io/aou-multiomics-analysis/susier` | Fine-mapping scripts from `R/scripts/` plus shared helpers from `R/utils/`. |
+| `containers/SusieR/Dockerfile` | `ghcr.io/aou-multiomics-analysis/susier` | Fine-mapping and CV scripts `susie.R`, `ComputeR2Susie.R`, and `PrepSusieCVPCs.R` plus shared helpers from `R/utils/`. |
 | `containers/PostAnalysis/Dockerfile` | `ghcr.io/aou-multiomics-analysis/susier/postanalysis` | Post-analysis scripts `AnnotateSusie.R`, `MergeSusie.R`, and `ComputeAncestrySkew.R`. |
 
 The fine-mapping image sets `SUSIER_FUNCTIONS_PATH=/opt/r/lib`, and the R scripts default to that location when sourcing shared helpers.
+
+Both images install their owned scripts under `/opt/r/scripts`. Compatibility symlinks are kept at `/` and `/tmp` for WDLs and existing Terra method configurations that reference those paths.
 
 ## GitHub Actions
 
@@ -15,7 +17,9 @@ The Docker workflows build and push images to GitHub Container Registry (`ghcr.i
 
 | Workflow | Dockerfile | Image | Rebuilds when |
 |---|---|---|---|
-| `.github/workflows/docker-image.yml` | `containers/SusieR/Dockerfile` | `ghcr.io/aou-multiomics-analysis/susier` | Fine-mapping image dependencies, `R/scripts/**`, or `R/utils/**` change. |
+| `.github/workflows/docker-image.yml` | `containers/SusieR/Dockerfile` | `ghcr.io/aou-multiomics-analysis/susier` | Fine-mapping image dependencies, owned fine-mapping scripts, or `R/utils/**` change. |
 | `.github/workflows/PostAnalysisImage.yml` | `containers/PostAnalysis/Dockerfile` | `ghcr.io/aou-multiomics-analysis/susier/postanalysis` | Post-analysis image dependencies, `R/scripts/AnnotateSusie.R`, `R/scripts/MergeSusie.R`, or `R/scripts/ComputeAncestrySkew.R` change. |
 
 The post-analysis image copies the scripts called by the aggregate, annotate, and ancestry skew WDL tasks.
+
+Each Docker workflow builds a local smoke-test image before pushing. The smoke tests verify that expected script paths exist and that the image can load the R packages needed by its scripts.


### PR DESCRIPTION
## Summary
- narrow the fine-mapping image to only fine-mapping/CV scripts
- install owned scripts under /opt/r/scripts with compatibility symlinks at / and /tmp
- add smoke-test builds to both Docker workflows before push
- check expected script paths and R package availability for each image
- add edgeR to the fine-mapping image because PrepSusieCVPCs.R uses edgeR:: at runtime

## Checks
- ruby YAML parse for workflows/dependabot/dockstore
- tools/validate_repo.sh
- R_LIBS_USER=/tmp/susier-r-lib Rscript tools/lint_r.R
- git diff --check