### PR TITLE
[codex] Support multi-phenotype fine-mapping per gene

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -9,9 +9,8 @@ These inputs are shared across the main fine-mapping workflows.
 | `TensorQTLPermutations` | Permutation p-values output from tensorQTL. |
 | `PhenotypeBed` | BED file for the gene or phenotype to be fine-mapped. |
 | `CisDistance` | Window in bp added to each side of the TSS for fine-mapping. |
-| `PhenotypeID` | Legacy single phenotype ID. When `PhenotypeIDs` or substring matching is used, this is used as the output prefix. |
-| `PhenotypeIDs` | Optional exact phenotype IDs to run together for one gene, such as multiple splicing introns. Omit to preserve the original single-phenotype behavior. |
-| `MatchPhenotypeIDSubstring` | If `true` and `PhenotypeIDs` is omitted, select all phenotype IDs containing `PhenotypeID`. Use for splice-junction IDs that embed the gene ID. |
+| `PhenotypeID` | Legacy single phenotype ID. When substring matching is used, this is used as the output prefix and gene ID to match within splice-junction phenotype IDs. |
+| `MatchPhenotypeIDSubstring` | If `true`, select all phenotype IDs containing `PhenotypeID`. Use for splice-junction IDs that embed the gene ID. |
 | `QTLCovariates` | Covariate table used in QTL calling. Use the same file given to tensorQTL. |
 | `SampleList` | List of sample IDs used in fine-mapping. Requires a header. |
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -29,9 +29,8 @@ Runs both input preparation and fine-mapping in a single workflow. First calls `
 | `TensorQTLPermutations` | File | Permutation p-values output from tensorQTL. |
 | `PhenotypeBed` | File | BED file for the gene or phenotype to be fine-mapped. |
 | `CisDistance` | Int | Window size in bp added to each side of the TSS. |
-| `PhenotypeID` | String | Legacy single phenotype ID. When `PhenotypeIDs` or substring matching is used, this becomes the output prefix. |
-| `PhenotypeIDs` | Array[String]? | Optional exact phenotype IDs to run together for one gene, such as multiple splicing introns. Omit to preserve the original single-phenotype behavior. |
-| `MatchPhenotypeIDSubstring` | Boolean | If `true` and `PhenotypeIDs` is omitted, select all phenotype IDs containing `PhenotypeID`. This supports splice-junction IDs that embed the gene ID. |
+| `PhenotypeID` | String | Legacy single phenotype ID. When substring matching is used, this becomes the output prefix and gene ID to match within splice-junction phenotype IDs. |
+| `MatchPhenotypeIDSubstring` | Boolean | If `true`, select all phenotype IDs containing `PhenotypeID`. This supports splice-junction IDs that embed the gene ID. |
 | `QTLCovariates` | File | Covariate table used in QTL calling. |
 | `SampleList` | File | Sample IDs used in fine-mapping. Requires a header. |
 | `susie_rscript` | File | Path to the `susie.R` script. |
@@ -57,8 +56,7 @@ Optional inputs in addition to the shared fine-mapping inputs:
 | Input | Type | Description |
 |---|---|---|
 | `MAF` | Float? | Minor allele frequency cutoff. |
-| `PhenotypeIDs` | Array[String]? | Optional exact phenotype IDs to run together under `OutputPrefix`. Omit to preserve the original single-phenotype behavior. |
-| `MatchPhenotypeIDSubstring` | Boolean | If `true` and `PhenotypeIDs` is omitted, select all phenotype IDs containing `OutputPrefix`. |
+| `MatchPhenotypeIDSubstring` | Boolean | If `true`, select all phenotype IDs containing `OutputPrefix`. |
 | `VariantList` | File? | Single-column file of variants formatted as `chr_pos_ref_alt` to restrict analysis. |
 | `AncestryFile` | File? | Ancestry metadata for per-population MAF filtering. |
 | `AdditionalGenotypesBed` | File? | Additional genotype BED file. |
@@ -74,8 +72,7 @@ Extracts phenotype rows and matching TensorQTL permutation rows for multi-phenot
 | `PhenotypeBed` | File | BED file containing phenotype rows. |
 | `TensorQTLPermutations` | File | TensorQTL permutation output. |
 | `PhenotypeID` | String | Legacy single phenotype ID, or gene/output prefix when selecting multiple embedded phenotype IDs. |
-| `PhenotypeIDs` | Array[String]? | Optional exact phenotype IDs to extract. Takes precedence over substring matching. |
-| `MatchPhenotypeIDSubstring` | Boolean | If `true` and `PhenotypeIDs` is omitted, select all phenotype IDs containing `PhenotypeID`. |
+| `MatchPhenotypeIDSubstring` | Boolean | If `true`, select all phenotype IDs containing `PhenotypeID`. |
 | `AddSkipRow` | Boolean | Add the legacy `skip` row used by `susie.R` phenotype matrices. Defaults to `true`. |
 | `NumPrempt` | Int | Number of preemptible retries. |
 
@@ -88,7 +85,7 @@ Extracts phenotype rows and matching TensorQTL permutation rows for multi-phenot
 
 ### `workflows/prepInputsSusieR.wdl` - Input Preparation Only
 
-Subsets genotype dosages, the phenotype BED file, and TensorQTL permutation results to the region surrounding `PhenotypeID`, all exact IDs in optional `PhenotypeIDs`, or all phenotype IDs containing `PhenotypeID` when `MatchPhenotypeIDSubstring` is true. This is the first step of `workflows/susieR.wdl` exposed as a standalone workflow, useful for preparing inputs once before running fine-mapping multiple times.
+Subsets genotype dosages, the phenotype BED file, and TensorQTL permutation results to the region surrounding `PhenotypeID`, or all phenotype IDs containing `PhenotypeID` when `MatchPhenotypeIDSubstring` is true. This is the first step of `workflows/susieR.wdl` exposed as a standalone workflow, useful for preparing inputs once before running fine-mapping multiple times.
 
 | Output | Description |
 |---|---|

--- a/workflows/ExtractMultiPhenotypeInputs.wdl
+++ b/workflows/ExtractMultiPhenotypeInputs.wdl
@@ -5,21 +5,17 @@ task ExtractMultiPhenotypeInputs {
         File PhenotypeBed
         File TensorQTLPermutations
         String PhenotypeID
-        Array[String]? PhenotypeIDs
         Boolean MatchPhenotypeIDSubstring = false
         Boolean AddSkipRow = true
         Int NumPrempt = 2
     }
 
-    Array[String] phenotype_ids = select_first([PhenotypeIDs, [PhenotypeID]])
-    File PhenotypeIDFile = write_lines(phenotype_ids)
-    String phenotype_match_mode = if defined(PhenotypeIDs) then "exact-list" else if MatchPhenotypeIDSubstring then "contains" else "exact"
+    String phenotype_match_mode = if MatchPhenotypeIDSubstring then "contains" else "exact"
 
     command <<<
         echo "Extracting phenotype inputs"
         echo "Phenotype match mode: ~{phenotype_match_mode}"
-        echo "Requested phenotype IDs:"
-        cat "~{PhenotypeIDFile}"
+        echo "Requested phenotype ID: ~{PhenotypeID}"
 
         zcat "~{PhenotypeBed}" | head -n 1 > phenotype_header.txt
 
@@ -29,7 +25,7 @@ task ExtractMultiPhenotypeInputs {
                 > phenotype_rows.bed
         else
             zcat "~{PhenotypeBed}" \
-                | awk 'NR==FNR {ids[$1]=1; next} FNR == 1 && $4 == "phenotype_id" {next} ($4 in ids)' "~{PhenotypeIDFile}" - \
+                | awk -v phenotype_id="~{PhenotypeID}" 'FNR == 1 && $4 == "phenotype_id" {next} $4 == phenotype_id' \
                 > phenotype_rows.bed
         fi
 
@@ -85,7 +81,6 @@ workflow ExtractMultiPhenotypeInputsWorkflow {
         File PhenotypeBed
         File TensorQTLPermutations
         String PhenotypeID
-        Array[String]? PhenotypeIDs
         Boolean MatchPhenotypeIDSubstring = false
         Boolean AddSkipRow = true
         Int NumPrempt = 2
@@ -96,7 +91,6 @@ workflow ExtractMultiPhenotypeInputsWorkflow {
             PhenotypeBed = PhenotypeBed,
             TensorQTLPermutations = TensorQTLPermutations,
             PhenotypeID = PhenotypeID,
-            PhenotypeIDs = PhenotypeIDs,
             MatchPhenotypeIDSubstring = MatchPhenotypeIDSubstring,
             AddSkipRow = AddSkipRow,
             NumPrempt = NumPrempt

--- a/workflows/prepInputsSusieR.wdl
+++ b/workflows/prepInputsSusieR.wdl
@@ -5,24 +5,20 @@ task PrepInputs {
         File GenotypeDosages
         File GenotypeDosageIndex
         String PhenotypeID
-        Array[String]? PhenotypeIDs
         Boolean MatchPhenotypeIDSubstring = false
         File PhenotypeBed
         File TensorQTLPermutations
         Int NumPrempt
         Int WindowSize = 1000000
     }
-    Array[String] phenotype_ids = select_first([PhenotypeIDs, [PhenotypeID]])
-    File PhenotypeIDFile = write_lines(phenotype_ids)
-    String phenotype_match_mode = if defined(PhenotypeIDs) then "exact-list" else if MatchPhenotypeIDSubstring then "contains" else "exact"
+    String phenotype_match_mode = if MatchPhenotypeIDSubstring then "contains" else "exact"
 
     command <<<
         echo "Extracting headers from files"
         headerPermutations=$(zcat "~{TensorQTLPermutations}" | head -n 1)
         headerBed=$(zcat "~{PhenotypeBed}" | head -n 1)
         echo "Phenotype match mode: ~{phenotype_match_mode}"
-        echo "Phenotype IDs selected for this run:"
-        cat "~{PhenotypeIDFile}"
+        echo "Phenotype ID selected for this run: ~{PhenotypeID}"
         
  
         echo "Bed file header:"
@@ -41,7 +37,7 @@ task PrepInputs {
                 > feature.bed
         else
             zcat "~{PhenotypeBed}" \
-                | awk 'BEGIN{OFS="\t"} NR==FNR {ids[$1]=1; next} FNR == 1 && $4 == "phenotype_id" {next} ($4 in ids) {$2=$2-~{WindowSize}; $3=$3+~{WindowSize}; if($2<1) $2=1; print}' "~{PhenotypeIDFile}" - \
+                | awk -v phenotype_id="~{PhenotypeID}" 'BEGIN{OFS="\t"} FNR == 1 && $4 == "phenotype_id" {next} $4 == phenotype_id {$2=$2-~{WindowSize}; $3=$3+~{WindowSize}; if($2<1) $2=1; print}' \
                 > feature.bed
         fi
         if [ ! -s feature.bed ]; then
@@ -61,7 +57,7 @@ task PrepInputs {
                 > feature.txt
         else
             zcat "~{TensorQTLPermutations}" \
-                | awk 'NR==FNR {ids[$1]=1; next} FNR == 1 && $1 == "phenotype_id" {next} ($1 in ids)' "~{PhenotypeIDFile}" - \
+                | awk -v phenotype_id="~{PhenotypeID}" 'FNR == 1 && $1 == "phenotype_id" {next} $1 == phenotype_id' \
                 > feature.txt
         fi
         if [ ! -s feature.txt ]; then
@@ -111,7 +107,6 @@ workflow PrepSusieRWorkflow {
         File PhenotypeBed
         Int NumPrempt
         String PhenotypeID
-        Array[String]? PhenotypeIDs
         Boolean MatchPhenotypeIDSubstring = false
         Int WindowSize = 1000000
 
@@ -121,7 +116,6 @@ workflow PrepSusieRWorkflow {
         input:
             TensorQTLPermutations = TensorQTLPermutations,
             PhenotypeID = PhenotypeID,
-            PhenotypeIDs = PhenotypeIDs,
             MatchPhenotypeIDSubstring = MatchPhenotypeIDSubstring,
             GenotypeDosages = GenotypeDosages,
             GenotypeDosageIndex = GenotypeDosageIndex,

--- a/workflows/susieR.wdl
+++ b/workflows/susieR.wdl
@@ -28,23 +28,19 @@ task PrepInputs {
         File GenotypeDosages
         File GenotypeDosageIndex
         String PhenotypeID
-        Array[String]? PhenotypeIDs
         Boolean MatchPhenotypeIDSubstring = false
         File PhenotypeBed
         File TensorQTLPermutations
         Int NumPrempt
     }
-    Array[String] phenotype_ids = select_first([PhenotypeIDs, [PhenotypeID]])
-    File PhenotypeIDFile = write_lines(phenotype_ids)
-    String phenotype_match_mode = if defined(PhenotypeIDs) then "exact-list" else if MatchPhenotypeIDSubstring then "contains" else "exact"
+    String phenotype_match_mode = if MatchPhenotypeIDSubstring then "contains" else "exact"
 
     command <<<
         echo "Extracting headers from files"
         headerPermutations=$(zcat "~{TensorQTLPermutations}" | head -n 1)
         headerBed=$(zcat "~{PhenotypeBed}" | head -n 1)
         echo "Phenotype match mode: ~{phenotype_match_mode}"
-        echo "Phenotype IDs selected for this run:"
-        cat "~{PhenotypeIDFile}"
+        echo "Phenotype ID selected for this run: ~{PhenotypeID}"
         
         echo "Bed file header:"
         echo "$headerBed"
@@ -62,7 +58,7 @@ task PrepInputs {
                 > feature.bed
         else
             zcat "~{PhenotypeBed}" \
-                | awk 'BEGIN{OFS="\t"} NR==FNR {ids[$1]=1; next} FNR == 1 && $4 == "phenotype_id" {next} ($4 in ids) {$2=$2-1000000; $3=$3+1000000; if($2<1) $2=1; print}' "~{PhenotypeIDFile}" - \
+                | awk -v phenotype_id="~{PhenotypeID}" 'BEGIN{OFS="\t"} FNR == 1 && $4 == "phenotype_id" {next} $4 == phenotype_id {$2=$2-1000000; $3=$3+1000000; if($2<1) $2=1; print}' \
                 > feature.bed
         fi
         if [ ! -s feature.bed ]; then
@@ -82,7 +78,7 @@ task PrepInputs {
                 > feature.txt
         else
             zcat "~{TensorQTLPermutations}" \
-                | awk 'NR==FNR {ids[$1]=1; next} FNR == 1 && $1 == "phenotype_id" {next} ($1 in ids)' "~{PhenotypeIDFile}" - \
+                | awk -v phenotype_id="~{PhenotypeID}" 'FNR == 1 && $1 == "phenotype_id" {next} $1 == phenotype_id' \
                 > feature.txt
         fi
         if [ ! -s feature.txt ]; then
@@ -214,7 +210,6 @@ workflow SusieRWorkflow {
         Int memory
         Int NumPrempt
         String PhenotypeID
-        Array[String]? PhenotypeIDs
         Boolean MatchPhenotypeIDSubstring = false
         Float MAF
     }
@@ -223,7 +218,6 @@ workflow SusieRWorkflow {
         input:
             TensorQTLPermutations = TensorQTLPermutations,
             PhenotypeID = PhenotypeID,
-            PhenotypeIDs = PhenotypeIDs,
             MatchPhenotypeIDSubstring = MatchPhenotypeIDSubstring,
             GenotypeDosages = GenotypeDosages,
             GenotypeDosageIndex = GenotypeDosageIndex,

--- a/workflows/susieRonly.wdl
+++ b/workflows/susieRonly.wdl
@@ -14,21 +14,17 @@ task susieR {
         Int memory
         Int NumPrempt
         Float? MAF
-        Array[String]? PhenotypeIDs
         Boolean MatchPhenotypeIDSubstring = false
         File? VariantList
         File? AncestryFile
         File? AdditionalGenotypesBed
     }
-    Array[String] phenotype_ids = select_first([PhenotypeIDs, [OutputPrefix]])
-    File PhenotypeIDFile = write_lines(phenotype_ids)
-    String phenotype_match_mode = if defined(PhenotypeIDs) then "exact-list" else if MatchPhenotypeIDSubstring then "contains" else "exact"
+    String phenotype_match_mode = if MatchPhenotypeIDSubstring then "contains" else "exact"
 
     command <<<
 
         echo "Phenotype match mode: ~{phenotype_match_mode}"
-        echo "Phenotype IDs selected for this run:"
-        cat "~{PhenotypeIDFile}"
+        echo "Output prefix selected for this run: ~{OutputPrefix}"
         zcat ~{PhenotypeBed} | head -n 1 > header.txt
         if [ "~{phenotype_match_mode}" = "contains" ]; then
             zcat ~{PhenotypeBed} \
@@ -36,7 +32,7 @@ task susieR {
                 > input_gene.txt
         else
             zcat ~{PhenotypeBed} \
-                | awk 'NR==FNR {ids[$1]=1; next} FNR == 1 && $4 == "phenotype_id" {next} ($4 in ids)' "~{PhenotypeIDFile}" - \
+                | awk -v phenotype_id="~{OutputPrefix}" 'FNR == 1 && $4 == "phenotype_id" {next} $4 == phenotype_id' \
                 > input_gene.txt
         fi
         if [ ! -s input_gene.txt ]; then
@@ -88,7 +84,6 @@ workflow SusieROnlyWorkflow {
         Int NumPrempt
         String OutputPrefix
         Float? MAF
-        Array[String]? PhenotypeIDs
         Boolean MatchPhenotypeIDSubstring = false
         File? VariantList
         File? AncestryFile
@@ -107,7 +102,6 @@ workflow SusieROnlyWorkflow {
             memory = memory,
             NumPrempt = NumPrempt,
             MAF = MAF,
-            PhenotypeIDs = PhenotypeIDs,
             MatchPhenotypeIDSubstring = MatchPhenotypeIDSubstring,
             VariantList = VariantList,
             AncestryFile = AncestryFile,


### PR DESCRIPTION
## Summary
- Add WDL-side substring matching so a gene ID can select all splice-junction phenotype IDs containing that gene ID.
- Keep legacy exact single-phenotype behavior when substring matching is disabled.
- Add a standalone phenotype/TensorQTL extraction workflow that does not subset genotype dosages.
- Remove the unsupported phenotype_group R flag so the workflows remain compatible with the current Docker image.

## Validation
- miniwdl check for touched WDLs
- ./tools/validate_repo.sh