### PR TITLE
Add SuSiE phenotype and variant diagnostics

### DIFF
--- a/R/scripts/susie.R
+++ b/R/scripts/susie.R
@@ -72,6 +72,10 @@ selected_phenotypes = phenotype_list %>%
   dplyr::filter(group_id %in% selected_group_ids) %>%
   dplyr::pull(phenotype_id) %>%
   setNames(as.list(.), .) 
+variant_position_report_file <- paste0(opt$out_prefix, ".variant_position_summary.tsv")
+if (file.exists(variant_position_report_file)) {
+  file.remove(variant_position_report_file)
+}
 reuse_genotype_matrix <- isTRUE(opt$reuse_genotype_matrix)
 reusable_genotype <- NULL
 if (reuse_genotype_matrix && length(selected_phenotypes) > 1) {
@@ -99,7 +103,8 @@ results = purrr::map(selected_phenotypes, ~finemapPhenotype(., selected_qtl_grou
                                                               MAF = MAF_threshold,
                                                               variant_list =variant_list,
                                                               additional_genotypes = additional_genotypes,
-                                                              reusable_genotype = reusable_genotype
+                                                              reusable_genotype = reusable_genotype,
+                                                              variant_report_file = variant_position_report_file
                                                               ))
 saveRDS(results,file = paste0(opt$out_prefix,'_susie.rds') )
 

--- a/R/utils/ImportFunctions.R
+++ b/R/utils/ImportFunctions.R
@@ -142,6 +142,78 @@ AdditionalGenotypes <- fread(AdditionalGenotypesBed,header = TRUE) %>%
 AdditionalGenotypes
 }
 
+reportPhenotypeIdPreview <- function(phenotype_ids, label, max_ids = 20) {
+    phenotype_ids <- unique(as.character(phenotype_ids))
+    phenotype_ids <- phenotype_ids[!is.na(phenotype_ids) & phenotype_ids != ""]
+    message(label, ": ", length(phenotype_ids), " unique ID(s)")
+    if (length(phenotype_ids) > 0) {
+        message("First ", min(max_ids, length(phenotype_ids)), " ", label, ":")
+        for (phenotype_id in utils::head(phenotype_ids, max_ids)) {
+            message("  ", phenotype_id)
+        }
+        if (length(phenotype_ids) > max_ids) {
+            message("  ... (", length(phenotype_ids) - max_ids, " additional ID(s) not shown)")
+        }
+    }
+    invisible(phenotype_ids)
+}
+
+reportPhenotypeMatchDiagnostics <- function(requested_phenotype_id,
+                                            phenotype_bed_ids,
+                                            tensorqtl_ids,
+                                            max_ids = 20) {
+    requested_phenotype_id <- as.character(requested_phenotype_id)
+    if (length(requested_phenotype_id) == 0 ||
+        is.na(requested_phenotype_id[[1]]) ||
+        requested_phenotype_id[[1]] == "") {
+        requested_phenotype_id <- "<not supplied>"
+    }
+
+    message("Requested phenotype ID(s): ", requested_phenotype_id[[1]])
+    phenotype_bed_ids <- reportPhenotypeIdPreview(
+        phenotype_bed_ids,
+        "available phenotype IDs in phenotype BED",
+        max_ids = max_ids
+    )
+    tensorqtl_ids <- reportPhenotypeIdPreview(
+        tensorqtl_ids,
+        "available phenotype IDs in TensorQTL permutations",
+        max_ids = max_ids
+    )
+    shared_ids <- intersect(phenotype_bed_ids, tensorqtl_ids)
+    reportPhenotypeIdPreview(
+        shared_ids,
+        "phenotype IDs shared between phenotype BED and TensorQTL permutations",
+        max_ids = max_ids
+    )
+
+    if (requested_phenotype_id[[1]] != "<not supplied>") {
+        bed_substring_matches <- phenotype_bed_ids[
+            grepl(requested_phenotype_id[[1]], phenotype_bed_ids, fixed = TRUE)
+        ]
+        tensorqtl_substring_matches <- tensorqtl_ids[
+            grepl(requested_phenotype_id[[1]], tensorqtl_ids, fixed = TRUE)
+        ]
+
+        reportPhenotypeIdPreview(
+            bed_substring_matches,
+            "phenotype BED substring fallback matches",
+            max_ids = max_ids
+        )
+        reportPhenotypeIdPreview(
+            tensorqtl_substring_matches,
+            "TensorQTL substring fallback matches",
+            max_ids = max_ids
+        )
+
+        if (length(bed_substring_matches) > 0 || length(tensorqtl_substring_matches) > 0) {
+            message("If the substring fallback matches are intended, rerun with MatchPhenotypeIDSubstring=true.")
+        }
+    }
+
+    invisible(NULL)
+}
+
 # Main data loader used by susie.R and ComputeR2Susie.R. It validates required
 # inputs, loads molecular/covariate/QTL data, and returns a named list that is
 # injected into the caller environment.
@@ -207,10 +279,18 @@ LoadData <- function(opt_list) {
     message('Loading QTL stats')
     
     
-    phenotype_table = importQtlmapPermutedPvalues(opt_list$phenotype_list) %>%
+    phenotype_table_all <- importQtlmapPermutedPvalues(opt_list$phenotype_list)
+    phenotype_table = phenotype_table_all %>%
         dplyr::filter(phenotype_id %in% expression_matrix$phenotype_id)
 
     filtered_list = dplyr::filter(phenotype_table, p_fdr < 0.05)
+    if (nrow(phenotype_table) == 0 || nrow(filtered_list) == 0) {
+        reportPhenotypeMatchDiagnostics(
+            requested_phenotype_id = opt_list$out_prefix,
+            phenotype_bed_ids = expression_matrix$phenotype_id,
+            tensorqtl_ids = phenotype_table_all$phenotype_id
+        )
+    }
     if (isTRUE(opt_list$select_top_phenotype_per_cluster)) {
         filtered_list <- selectTopPhenotypePerCluster(
             filtered_list,
@@ -228,7 +308,7 @@ LoadData <- function(opt_list) {
     }
     message("Number of phenotypes included for analysis: ", nrow(phenotype_list))
     if (nrow(phenotype_list) == 0) {
-        stop('No phenotypes found matching between phenotype table and expression matrix')
+        stop('No phenotypes found matching between phenotype table and expression matrix after filtering')
     }
 
     if (!is.null(opt_list$AncestryMetadata)) {

--- a/R/utils/SusieFunctions.R
+++ b/R/utils/SusieFunctions.R
@@ -91,7 +91,30 @@ parse_variant_ids <- function(variant_ids) {
   )
 }
 
-reportVariantDirectionCounts <- function(variant_ids, feature_meta, context = "genotype matrix") {
+writeVariantPositionSummary <- function(summary_df, output_file) {
+  if (is.null(output_file)) {
+    return(invisible(NULL))
+  }
+
+  write_header <- !file.exists(output_file)
+  utils::write.table(
+    summary_df,
+    file = output_file,
+    sep = "\t",
+    quote = FALSE,
+    row.names = FALSE,
+    col.names = write_header,
+    append = !write_header
+  )
+  invisible(NULL)
+}
+
+reportVariantDirectionCounts <- function(variant_ids,
+                                         feature_meta,
+                                         context = "genotype matrix",
+                                         output_file = NULL,
+                                         requested_window_start = NA_real_,
+                                         requested_window_end = NA_real_) {
   variant_info <- parse_variant_ids(variant_ids)
   feature_meta <- feature_meta[seq_len(min(nrow(feature_meta), 1)), , drop = FALSE]
 
@@ -114,10 +137,44 @@ reportVariantDirectionCounts <- function(variant_ids, feature_meta, context = "g
   }
 
   same_chr <- variant_info$chromosome == feature_chr & !is.na(variant_info$position)
+  signed_distances <- variant_info$position[same_chr] - feature_pos
+  abs_distances <- abs(signed_distances)
   upstream_count <- sum(same_chr & variant_info$position < feature_pos)
   downstream_count <- sum(same_chr & variant_info$position > feature_pos)
   at_feature_count <- sum(same_chr & variant_info$position == feature_pos)
   uncounted_count <- sum(!same_chr | is.na(variant_info$position))
+  min_signed_distance <- if (length(signed_distances) > 0) min(signed_distances) else NA_real_
+  max_signed_distance <- if (length(signed_distances) > 0) max(signed_distances) else NA_real_
+  min_abs_distance <- if (length(abs_distances) > 0) min(abs_distances) else NA_real_
+  max_abs_distance <- if (length(abs_distances) > 0) max(abs_distances) else NA_real_
+  requested_window_size <- if (
+    !is.na(requested_window_start) &&
+      !is.na(requested_window_end)
+  ) {
+    requested_window_end - requested_window_start + 1
+  } else {
+    NA_real_
+  }
+  summary_df <- data.frame(
+    phenotype_id = feature_id,
+    context = context,
+    feature_chromosome = feature_chr,
+    feature_position = feature_pos,
+    requested_window_start = requested_window_start,
+    requested_window_end = requested_window_end,
+    requested_window_size_bp = requested_window_size,
+    total_variants_tested = length(variant_ids),
+    same_chromosome_parseable_variants = sum(same_chr),
+    upstream_variants = upstream_count,
+    downstream_variants = downstream_count,
+    variants_at_feature_coordinate = at_feature_count,
+    uncounted_variants = uncounted_count,
+    min_abs_distance_bp = min_abs_distance,
+    max_abs_distance_bp = max_abs_distance,
+    min_signed_distance_bp = min_signed_distance,
+    max_signed_distance_bp = max_signed_distance,
+    stringsAsFactors = FALSE
+  )
 
   message(
     "Variant position summary for ",
@@ -129,6 +186,8 @@ reportVariantDirectionCounts <- function(variant_ids, feature_meta, context = "g
     " after loading ",
     context,
     ": ",
+    length(variant_ids),
+    " total variants tested, ",
     upstream_count,
     " upstream, ",
     downstream_count,
@@ -136,8 +195,20 @@ reportVariantDirectionCounts <- function(variant_ids, feature_meta, context = "g
     at_feature_count,
     " at the feature coordinate, ",
     uncounted_count,
-    " uncounted due to chromosome mismatch or unparsable position"
+    " uncounted due to chromosome mismatch or unparsable position, ",
+    "min abs distance ",
+    min_abs_distance,
+    " bp, max abs distance ",
+    max_abs_distance,
+    " bp, requested window ",
+    requested_window_start,
+    "-",
+    requested_window_end,
+    " (",
+    requested_window_size,
+    " bp)"
   )
+  writeVariantPositionSummary(summary_df, output_file)
   invisible(NULL)
 }
 
@@ -315,7 +386,7 @@ MergeAdditionalGenotypes <- function(GenotypeMatrix, AdditionalGenotypes) {
 
 # Fine-map one phenotype by loading local cis dosages, residualizing expression
 # and genotypes against covariates, then fitting susieR.
-finemapPhenotype <- function(phenotype_id, se, genotype_file, covariates, cis_distance,ancestry_data = NULL,MAF = 0,variant_list = NULL,additional_genotypes = NULL,reusable_genotype = NULL){
+finemapPhenotype <- function(phenotype_id, se, genotype_file, covariates, cis_distance,ancestry_data = NULL,MAF = 0,variant_list = NULL,additional_genotypes = NULL,reusable_genotype = NULL,variant_report_file = NULL){
   message("Processing phenotype: ", phenotype_id)
   
   # Extract and rank-normalize the target phenotype from the SummarizedExperiment.
@@ -364,7 +435,10 @@ finemapPhenotype <- function(phenotype_id, se, genotype_file, covariates, cis_di
       reportVariantDirectionCounts(
         variant_names,
         gene_meta,
-        context = "reusable genotype matrix subset"
+        context = "reusable genotype matrix subset",
+        output_file = variant_report_file,
+        requested_window_start = phenotype_start,
+        requested_window_end = phenotype_end
       )
       fitted <- susieR::susie(gt_hat, expression_vector,
                               L = 10,
@@ -381,25 +455,21 @@ finemapPhenotype <- function(phenotype_id, se, genotype_file, covariates, cis_di
 
   # Align covariates to phenotype sample order and add an intercept column.
   covariates_matrix = cbind(covariates[gene_vector$genotype_id,], 1)
+  phenotype_start <- gene_meta$phenotype_pos - cis_distance
+  phenotype_end <- gene_meta$phenotype_pos + cis_distance
   
   if (is.character(genotype_file)) {
   #Import genotype matrix
   message('Loading Genotype Matrix')
   genotype_matrix = eQTLUtils::extractGenotypeMatrixFromDosage(
     chr = gene_meta$chromosome, 
-    start = gene_meta$phenotype_pos - cis_distance, 
-    end = gene_meta$phenotype_pos + cis_distance, 
+    start = phenotype_start,
+    end = phenotype_end,
     dosage_file = genotype_file) %>% 
     filterMAF(ancestry_data,MAF_threshold = MAF,variant_list = variant_list) 
-    reportVariantDirectionCounts(rownames(genotype_matrix), gene_meta)
    } else {
     message('Using pre-loaded genotype matrix')
     genotype_matrix <- genotype_file
-    reportVariantDirectionCounts(
-      rownames(genotype_matrix),
-      gene_meta,
-      context = "pre-loaded genotype matrix"
-    )
     }
   # Residualize expression against covariates using a hat matrix.
   message('Residualizing gene expression')
@@ -455,6 +525,14 @@ finemapPhenotype <- function(phenotype_id, se, genotype_file, covariates, cis_di
   # operations drop or reorder row names.
   gt_matrix <- impute_matrix_rowmean(gt_matrix, missing_value = -1)
   variant_names <- rownames(gt_matrix)
+  reportVariantDirectionCounts(
+    variant_names,
+    gene_meta,
+    context = "fine-mapping genotype matrix",
+    output_file = variant_report_file,
+    requested_window_start = phenotype_start,
+    requested_window_end = phenotype_end
+  )
   # Standardize genotypes (subtract row means)
 
   message('Standardizing genotypes')

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -6,13 +6,14 @@ The workflow entrypoint scripts live in `R/scripts/`. Shared helper functions li
 
 The main fine-mapping script. It loads genotype dosages, expression or phenotype data, covariates, and a list of phenotypes to fine-map, then runs susieR on each phenotype in the provided cis window.
 
-Results are written to three Parquet files:
+Results are written to three Parquet files plus one variant-position diagnostic TSV:
 
 | Output | Description |
 |---|---|
 | `<out_prefix>.parquet` | Variants belonging to credible sets. Corresponds to the `SusieParquet` WDL output. |
 | `<out_prefix>.lbf_variable.parquet` | Log-Bayes factors per credible set. Corresponds to `SusielbfParquet`. |
 | `<out_prefix>.full_susie.parquet` | Fine-mapping statistics for all tested variants. Corresponds to `FullSusieParquet`. |
+| `<out_prefix>.variant_position_summary.tsv` | Per-phenotype summary of tested variant counts, upstream/downstream counts, min/max variant distance from the feature, and requested cis-window size. Corresponds to `VariantPositionSummary`. |
 
 Key command-line arguments:
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -46,6 +46,7 @@ Runs both input preparation and fine-mapping in a single workflow. First calls `
 | `SusieParquet` | Variants in credible sets. |
 | `SusielbfParquet` | Log-Bayes factors per credible set. |
 | `FullSusieParquet` | Fine-mapping statistics for all tested variants. |
+| `VariantPositionSummary` | TSV summary of tested variant counts, upstream/downstream counts, min/max variant distance from the feature, and requested cis-window size. |
 | `SubsetBed` | Subsetted BED file for the phenotype region. |
 | `SubsetDosages` | Subsetted genotype dosage file. |
 | `SubsetDosagesIndex` | Index for the subsetted dosage file. |
@@ -67,7 +68,7 @@ Optional inputs in addition to the shared fine-mapping inputs:
 | `AncestryFile` | File? | Ancestry metadata for per-population MAF filtering. |
 | `AdditionalGenotypesBed` | File? | Additional genotype BED file. |
 
-Outputs are `SusieParquet`, `SusielbfParquet`, and `FullSusieParquet`.
+Outputs are `SusieParquet`, `SusielbfParquet`, `FullSusieParquet`, and `VariantPositionSummary`.
 
 ### `workflows/ExtractMultiPhenotypeInputs.wdl` - Phenotype Extraction Only
 

--- a/workflows/prepInputsSusieR.wdl
+++ b/workflows/prepInputsSusieR.wdl
@@ -26,37 +26,6 @@ task PrepInputs {
 
         echo "TensorQTL file header"
         echo "$headerPermutations"
-
-        report_phenotype_match_failure() {
-            echo "Requested phenotype ID(s): $1" >&2
-            zcat "~{PhenotypeBed}" \
-                | awk -F'\t' '
-                    FNR == 1 && $4 == "phenotype_id" {next}
-                    $4 != "" && !seen[$4]++ {
-                        count++
-                        if (count <= 20) preview[count] = $4
-                    }
-                    END {
-                        printf "Available phenotype IDs in PhenotypeBed: %d unique ID(s)\n", count > "/dev/stderr"
-                        if (count > 0) {
-                            print "First available phenotype IDs:" > "/dev/stderr"
-                            for (i = 1; i <= count && i <= 20; i++) print preview[i] > "/dev/stderr"
-                            if (count > 20) printf "... (%d additional phenotype IDs not shown)\n", count - 20 > "/dev/stderr"
-                        }
-                    }'
-            zcat "~{PhenotypeBed}" \
-                | awk -v needle="$1" 'FNR == 1 && $4 == "phenotype_id" {next} index($4, needle) > 0' \
-                > phenotype_substring_matches.bed
-            substring_match_count=$(wc -l < phenotype_substring_matches.bed | tr -d ' ')
-            if [ "$substring_match_count" -gt 0 ]; then
-                echo "Substring fallback found ${substring_match_count} PhenotypeBed row(s) containing the requested ID." >&2
-                echo "First matching phenotype IDs from substring fallback:" >&2
-                awk -F'\t' '!seen[$4]++ {print $4; if (++n == 20) exit}' phenotype_substring_matches.bed >&2
-                echo "If these are intended, rerun with MatchPhenotypeIDSubstring=true." >&2
-            else
-                echo "Substring fallback found 0 PhenotypeBed rows containing the requested ID." >&2
-            fi
-        }
         
         #zcat ~{GenotypeDosages} |  awk 'NR==1 { if ($0 ~ /^#/) print; else print "#" $0; exit }'  > dosage_header.txt
         zcat "~{GenotypeDosages}" |  awk 'NR==1 {print $0; exit }'  > dosage_header.txt
@@ -73,7 +42,6 @@ task PrepInputs {
         fi
         if [ ! -s feature.bed ]; then
             echo "No rows in PhenotypeBed matched the requested phenotype IDs" >&2
-            report_phenotype_match_failure "~{PhenotypeID}"
             exit 1
         fi
         

--- a/workflows/prepInputsSusieR.wdl
+++ b/workflows/prepInputsSusieR.wdl
@@ -26,6 +26,37 @@ task PrepInputs {
 
         echo "TensorQTL file header"
         echo "$headerPermutations"
+
+        report_phenotype_match_failure() {
+            echo "Requested phenotype ID(s): $1" >&2
+            zcat "~{PhenotypeBed}" \
+                | awk -F'\t' '
+                    FNR == 1 && $4 == "phenotype_id" {next}
+                    $4 != "" && !seen[$4]++ {
+                        count++
+                        if (count <= 20) preview[count] = $4
+                    }
+                    END {
+                        printf "Available phenotype IDs in PhenotypeBed: %d unique ID(s)\n", count > "/dev/stderr"
+                        if (count > 0) {
+                            print "First available phenotype IDs:" > "/dev/stderr"
+                            for (i = 1; i <= count && i <= 20; i++) print preview[i] > "/dev/stderr"
+                            if (count > 20) printf "... (%d additional phenotype IDs not shown)\n", count - 20 > "/dev/stderr"
+                        }
+                    }'
+            zcat "~{PhenotypeBed}" \
+                | awk -v needle="$1" 'FNR == 1 && $4 == "phenotype_id" {next} index($4, needle) > 0' \
+                > phenotype_substring_matches.bed
+            substring_match_count=$(wc -l < phenotype_substring_matches.bed | tr -d ' ')
+            if [ "$substring_match_count" -gt 0 ]; then
+                echo "Substring fallback found ${substring_match_count} PhenotypeBed row(s) containing the requested ID." >&2
+                echo "First matching phenotype IDs from substring fallback:" >&2
+                awk -F'\t' '!seen[$4]++ {print $4; if (++n == 20) exit}' phenotype_substring_matches.bed >&2
+                echo "If these are intended, rerun with MatchPhenotypeIDSubstring=true." >&2
+            else
+                echo "Substring fallback found 0 PhenotypeBed rows containing the requested ID." >&2
+            fi
+        }
         
         #zcat ~{GenotypeDosages} |  awk 'NR==1 { if ($0 ~ /^#/) print; else print "#" $0; exit }'  > dosage_header.txt
         zcat "~{GenotypeDosages}" |  awk 'NR==1 {print $0; exit }'  > dosage_header.txt
@@ -42,6 +73,7 @@ task PrepInputs {
         fi
         if [ ! -s feature.bed ]; then
             echo "No rows in PhenotypeBed matched the requested phenotype IDs" >&2
+            report_phenotype_match_failure "~{PhenotypeID}"
             exit 1
         fi
         

--- a/workflows/susieR.wdl
+++ b/workflows/susieR.wdl
@@ -47,6 +47,37 @@ task PrepInputs {
 
         echo "TensorQTL file header"
         echo "$headerPermutations"
+
+        report_phenotype_match_failure() {
+            echo "Requested phenotype ID(s): $1" >&2
+            zcat "~{PhenotypeBed}" \
+                | awk -F'\t' '
+                    FNR == 1 && $4 == "phenotype_id" {next}
+                    $4 != "" && !seen[$4]++ {
+                        count++
+                        if (count <= 20) preview[count] = $4
+                    }
+                    END {
+                        printf "Available phenotype IDs in PhenotypeBed: %d unique ID(s)\n", count > "/dev/stderr"
+                        if (count > 0) {
+                            print "First available phenotype IDs:" > "/dev/stderr"
+                            for (i = 1; i <= count && i <= 20; i++) print preview[i] > "/dev/stderr"
+                            if (count > 20) printf "... (%d additional phenotype IDs not shown)\n", count - 20 > "/dev/stderr"
+                        }
+                    }'
+            zcat "~{PhenotypeBed}" \
+                | awk -v needle="$1" 'FNR == 1 && $4 == "phenotype_id" {next} index($4, needle) > 0' \
+                > phenotype_substring_matches.bed
+            substring_match_count=$(wc -l < phenotype_substring_matches.bed | tr -d ' ')
+            if [ "$substring_match_count" -gt 0 ]; then
+                echo "Substring fallback found ${substring_match_count} PhenotypeBed row(s) containing the requested ID." >&2
+                echo "First matching phenotype IDs from substring fallback:" >&2
+                awk -F'\t' '!seen[$4]++ {print $4; if (++n == 20) exit}' phenotype_substring_matches.bed >&2
+                echo "If these are intended, rerun with MatchPhenotypeIDSubstring=true." >&2
+            else
+                echo "Substring fallback found 0 PhenotypeBed rows containing the requested ID." >&2
+            fi
+        }
         
         #zcat ~{GenotypeDosages} |  awk 'NR==1 { if ($0 ~ /^#/) print; else print "#" $0; exit }'  > dosage_header.txt
         zcat "~{GenotypeDosages}" |  awk 'NR==1 {print $0; exit }'  > dosage_header.txt
@@ -63,6 +94,7 @@ task PrepInputs {
         fi
         if [ ! -s feature.bed ]; then
             echo "No rows in PhenotypeBed matched the requested phenotype IDs" >&2
+            report_phenotype_match_failure "~{PhenotypeID}"
             exit 1
         fi
         

--- a/workflows/susieR.wdl
+++ b/workflows/susieR.wdl
@@ -174,6 +174,7 @@ task susieR {
         File SusieParquet = "${OutputPrefix}.parquet"
         File lbfParquet = "${OutputPrefix}.lbf_variable.parquet"
         File FullSusieParquet = "${OutputPrefix}.full_susie.parquet"
+        File VariantPositionSummary = "${OutputPrefix}.variant_position_summary.tsv"
     }
 }
 
@@ -273,6 +274,7 @@ workflow SusieRWorkflow {
         File SusieParquet = susieR.SusieParquet
         File SusielbfParquet = susieR.lbfParquet
         File FullSusieParquet = susieR.FullSusieParquet
+        File VariantPositionSummary = susieR.VariantPositionSummary
         File SubsetBed = PrepInputs.SubsetBed
         #File SubsetBedIndex = PrepInputs.SubsetBedIndex
         File SubsetDosages = PrepInputs.SubsetDosages

--- a/workflows/susieR.wdl
+++ b/workflows/susieR.wdl
@@ -47,37 +47,6 @@ task PrepInputs {
 
         echo "TensorQTL file header"
         echo "$headerPermutations"
-
-        report_phenotype_match_failure() {
-            echo "Requested phenotype ID(s): $1" >&2
-            zcat "~{PhenotypeBed}" \
-                | awk -F'\t' '
-                    FNR == 1 && $4 == "phenotype_id" {next}
-                    $4 != "" && !seen[$4]++ {
-                        count++
-                        if (count <= 20) preview[count] = $4
-                    }
-                    END {
-                        printf "Available phenotype IDs in PhenotypeBed: %d unique ID(s)\n", count > "/dev/stderr"
-                        if (count > 0) {
-                            print "First available phenotype IDs:" > "/dev/stderr"
-                            for (i = 1; i <= count && i <= 20; i++) print preview[i] > "/dev/stderr"
-                            if (count > 20) printf "... (%d additional phenotype IDs not shown)\n", count - 20 > "/dev/stderr"
-                        }
-                    }'
-            zcat "~{PhenotypeBed}" \
-                | awk -v needle="$1" 'FNR == 1 && $4 == "phenotype_id" {next} index($4, needle) > 0' \
-                > phenotype_substring_matches.bed
-            substring_match_count=$(wc -l < phenotype_substring_matches.bed | tr -d ' ')
-            if [ "$substring_match_count" -gt 0 ]; then
-                echo "Substring fallback found ${substring_match_count} PhenotypeBed row(s) containing the requested ID." >&2
-                echo "First matching phenotype IDs from substring fallback:" >&2
-                awk -F'\t' '!seen[$4]++ {print $4; if (++n == 20) exit}' phenotype_substring_matches.bed >&2
-                echo "If these are intended, rerun with MatchPhenotypeIDSubstring=true." >&2
-            else
-                echo "Substring fallback found 0 PhenotypeBed rows containing the requested ID." >&2
-            fi
-        }
         
         #zcat ~{GenotypeDosages} |  awk 'NR==1 { if ($0 ~ /^#/) print; else print "#" $0; exit }'  > dosage_header.txt
         zcat "~{GenotypeDosages}" |  awk 'NR==1 {print $0; exit }'  > dosage_header.txt
@@ -94,7 +63,6 @@ task PrepInputs {
         fi
         if [ ! -s feature.bed ]; then
             echo "No rows in PhenotypeBed matched the requested phenotype IDs" >&2
-            report_phenotype_match_failure "~{PhenotypeID}"
             exit 1
         fi
         

--- a/workflows/susieRonly.wdl
+++ b/workflows/susieRonly.wdl
@@ -29,6 +29,38 @@ task susieR {
         echo "Phenotype match mode: ~{phenotype_match_mode}"
         echo "Output prefix selected for this run: ~{OutputPrefix}"
         zcat ~{PhenotypeBed} | head -n 1 > header.txt
+
+        report_phenotype_match_failure() {
+            echo "Requested phenotype ID(s): $1" >&2
+            zcat ~{PhenotypeBed} \
+                | awk -F'\t' '
+                    FNR == 1 && $4 == "phenotype_id" {next}
+                    $4 != "" && !seen[$4]++ {
+                        count++
+                        if (count <= 20) preview[count] = $4
+                    }
+                    END {
+                        printf "Available phenotype IDs in PhenotypeBed: %d unique ID(s)\n", count > "/dev/stderr"
+                        if (count > 0) {
+                            print "First available phenotype IDs:" > "/dev/stderr"
+                            for (i = 1; i <= count && i <= 20; i++) print preview[i] > "/dev/stderr"
+                            if (count > 20) printf "... (%d additional phenotype IDs not shown)\n", count - 20 > "/dev/stderr"
+                        }
+                    }'
+            zcat ~{PhenotypeBed} \
+                | awk -v needle="$1" 'FNR == 1 && $4 == "phenotype_id" {next} index($4, needle) > 0' \
+                > phenotype_substring_matches.bed
+            substring_match_count=$(wc -l < phenotype_substring_matches.bed | tr -d ' ')
+            if [ "$substring_match_count" -gt 0 ]; then
+                echo "Substring fallback found ${substring_match_count} PhenotypeBed row(s) containing the requested ID." >&2
+                echo "First matching phenotype IDs from substring fallback:" >&2
+                awk -F'\t' '!seen[$4]++ {print $4; if (++n == 20) exit}' phenotype_substring_matches.bed >&2
+                echo "If these are intended, rerun with MatchPhenotypeIDSubstring=true." >&2
+            else
+                echo "Substring fallback found 0 PhenotypeBed rows containing the requested ID." >&2
+            fi
+        }
+
         if [ "~{phenotype_match_mode}" = "contains" ]; then
             zcat ~{PhenotypeBed} \
                 | awk -v needle="~{OutputPrefix}" 'FNR == 1 && $4 == "phenotype_id" {next} index($4, needle) > 0' \
@@ -40,6 +72,7 @@ task susieR {
         fi
         if [ ! -s input_gene.txt ]; then
             echo "No rows in PhenotypeBed matched the requested phenotype IDs" >&2
+            report_phenotype_match_failure "~{OutputPrefix}"
             exit 1
         fi
         head -n 1 input_gene.txt | awk -F'\t' 'BEGIN{OFS="\t"} {$4="skip"; print}' > skip.txt        

--- a/workflows/susieRonly.wdl
+++ b/workflows/susieRonly.wdl
@@ -29,38 +29,6 @@ task susieR {
         echo "Phenotype match mode: ~{phenotype_match_mode}"
         echo "Output prefix selected for this run: ~{OutputPrefix}"
         zcat ~{PhenotypeBed} | head -n 1 > header.txt
-
-        report_phenotype_match_failure() {
-            echo "Requested phenotype ID(s): $1" >&2
-            zcat ~{PhenotypeBed} \
-                | awk -F'\t' '
-                    FNR == 1 && $4 == "phenotype_id" {next}
-                    $4 != "" && !seen[$4]++ {
-                        count++
-                        if (count <= 20) preview[count] = $4
-                    }
-                    END {
-                        printf "Available phenotype IDs in PhenotypeBed: %d unique ID(s)\n", count > "/dev/stderr"
-                        if (count > 0) {
-                            print "First available phenotype IDs:" > "/dev/stderr"
-                            for (i = 1; i <= count && i <= 20; i++) print preview[i] > "/dev/stderr"
-                            if (count > 20) printf "... (%d additional phenotype IDs not shown)\n", count - 20 > "/dev/stderr"
-                        }
-                    }'
-            zcat ~{PhenotypeBed} \
-                | awk -v needle="$1" 'FNR == 1 && $4 == "phenotype_id" {next} index($4, needle) > 0' \
-                > phenotype_substring_matches.bed
-            substring_match_count=$(wc -l < phenotype_substring_matches.bed | tr -d ' ')
-            if [ "$substring_match_count" -gt 0 ]; then
-                echo "Substring fallback found ${substring_match_count} PhenotypeBed row(s) containing the requested ID." >&2
-                echo "First matching phenotype IDs from substring fallback:" >&2
-                awk -F'\t' '!seen[$4]++ {print $4; if (++n == 20) exit}' phenotype_substring_matches.bed >&2
-                echo "If these are intended, rerun with MatchPhenotypeIDSubstring=true." >&2
-            else
-                echo "Substring fallback found 0 PhenotypeBed rows containing the requested ID." >&2
-            fi
-        }
-
         if [ "~{phenotype_match_mode}" = "contains" ]; then
             zcat ~{PhenotypeBed} \
                 | awk -v needle="~{OutputPrefix}" 'FNR == 1 && $4 == "phenotype_id" {next} index($4, needle) > 0' \
@@ -72,7 +40,6 @@ task susieR {
         fi
         if [ ! -s input_gene.txt ]; then
             echo "No rows in PhenotypeBed matched the requested phenotype IDs" >&2
-            report_phenotype_match_failure "~{OutputPrefix}"
             exit 1
         fi
         head -n 1 input_gene.txt | awk -F'\t' 'BEGIN{OFS="\t"} {$4="skip"; print}' > skip.txt        

--- a/workflows/susieRonly.wdl
+++ b/workflows/susieRonly.wdl
@@ -69,6 +69,7 @@ task susieR {
         File SusieParquet = "${OutputPrefix}.parquet"
         File lbfParquet = "${OutputPrefix}.lbf_variable.parquet"
         File FullSusieParquet = "${OutputPrefix}.full_susie.parquet"
+        File VariantPositionSummary = "${OutputPrefix}.variant_position_summary.tsv"
         File SusieObject = "${OutputPrefix}_susie.rds"
     }
 }
@@ -120,6 +121,7 @@ workflow SusieROnlyWorkflow {
             File SusieParquet = susieR.SusieParquet
             File SusielbfParquet = susieR.lbfParquet
             File FullSusieParquet = susieR.FullSusieParquet
+            File VariantPositionSummary = susieR.VariantPositionSummary
             File SusieObject = susieR.SusieObject
         }
 }


### PR DESCRIPTION
## Summary

- Add R-side phenotype match diagnostics in the SuSiE data loader when no phenotypes remain after matching/filtering.
- Write a per-phenotype variant position summary TSV from fine-mapping.
- Expose the TSV as `VariantPositionSummary` in `susieR.wdl` and `susieRonly.wdl`.
- Document the new output.

## Details

The phenotype diagnostic reports requested phenotype ID, available IDs in the phenotype BED, available IDs in TensorQTL permutations, shared IDs, and substring fallback matches.

The variant report includes total variants tested, upstream/downstream counts, variants at the feature coordinate, uncounted variants, min/max signed and absolute distance from the feature, and requested cis-window start/end/size.

## Validation

- `bash tools/validate_repo.sh`
- Focused R smoke test for `reportVariantDirectionCounts()` TSV writing and distance/window fields