### PR TITLE
Center phenotype windows on BED midpoint

### DIFF
--- a/R/utils/ImportFunctions.R
+++ b/R/utils/ImportFunctions.R
@@ -248,12 +248,35 @@ LoadData <- function(opt_list) {
     covariates_matrix = covariates_matrix[,exclude_cov]
 
     # Convert BED columns into phenotype metadata required by eQTLUtils.
+    # Use the interval midpoint so 1 bp site/TSS intervals and already-expanded
+    # phenotype windows both fine-map around the feature center.
     phenotype_meta<- expression_matrix %>% 
         select(1,2,3,4) %>% 
-        dplyr::rename('chromosome' = 1,'phenotype_pos' = 2) %>% 
+        dplyr::rename('chromosome' = 1,'phenotype_start' = 2,'phenotype_end' = 3) %>%
+        mutate(
+            phenotype_start = suppressWarnings(as.numeric(phenotype_start)),
+            phenotype_end = suppressWarnings(as.numeric(phenotype_end)),
+            phenotype_pos = dplyr::if_else(
+                !is.na(phenotype_start) & !is.na(phenotype_end),
+                floor((phenotype_start + phenotype_end) / 2),
+                phenotype_start
+            )
+        ) %>%
         mutate(strand  = 1) %>% 
         mutate(gene_id = phenotype_id,group_id = phenotype_id) %>%
-        select(phenotype_id,group_id,gene_id,chromosome,phenotype_pos,strand)
+        select(phenotype_id,group_id,gene_id,chromosome,phenotype_pos,phenotype_start,phenotype_end,strand)
+    expanded_interval_count <- sum(
+        !is.na(phenotype_meta$phenotype_start) &
+        !is.na(phenotype_meta$phenotype_end) &
+        (phenotype_meta$phenotype_end - phenotype_meta$phenotype_start) > 1
+    )
+    if (expanded_interval_count > 0) {
+        message(
+            "Detected ",
+            expanded_interval_count,
+            " phenotype BED intervals wider than 1 bp; using interval midpoint as the feature coordinate"
+        )
+    }
     # Convert the sample list into the sample metadata shape required by
     # eQTLUtils; CV workflows can omit this because metadata is stored in CV RDS.
     message('Loading sample metadata')

--- a/R/utils/ImportFunctions.R
+++ b/R/utils/ImportFunctions.R
@@ -214,6 +214,60 @@ reportPhenotypeMatchDiagnostics <- function(requested_phenotype_id,
     invisible(NULL)
 }
 
+validatePreparedWindowCoverage <- function(phenotype_meta, cis_distance, max_examples = 5) {
+    if (is.null(cis_distance) || is.na(cis_distance) || cis_distance <= 0) {
+        return(invisible(NULL))
+    }
+
+    windowed_meta <- phenotype_meta %>%
+        dplyr::filter(
+            phenotype_id != "skip",
+            !is.na(phenotype_start),
+            !is.na(phenotype_end),
+            (phenotype_end - phenotype_start) > 1
+        ) %>%
+        dplyr::mutate(
+            requested_start = pmax(1, phenotype_pos - cis_distance),
+            requested_end = phenotype_pos + cis_distance + 1,
+            missing_requested_window = phenotype_start > requested_start | phenotype_end < requested_end
+        ) %>%
+        dplyr::filter(missing_requested_window)
+
+    if (nrow(windowed_meta) == 0) {
+        return(invisible(NULL))
+    }
+
+    examples <- windowed_meta %>%
+        utils::head(max_examples) %>%
+        dplyr::transmute(
+            detail = paste0(
+                phenotype_id,
+                " available ",
+                chromosome,
+                ":",
+                phenotype_start,
+                "-",
+                phenotype_end,
+                ", requested ",
+                chromosome,
+                ":",
+                requested_start,
+                "-",
+                requested_end,
+                ", feature midpoint ",
+                phenotype_pos
+            )
+        ) %>%
+        dplyr::pull(detail)
+
+    stop(
+        "Requested CisDistance is larger than at least one prepared phenotype BED interval. ",
+        "This can drop variants from pre-subset dosage files. ",
+        "Re-run PrepInputs with WindowSize >= CisDistance or reduce CisDistance. Examples: ",
+        paste(examples, collapse = " | ")
+    )
+}
+
 # Main data loader used by susie.R and ComputeR2Susie.R. It validates required
 # inputs, loads molecular/covariate/QTL data, and returns a named list that is
 # injected into the caller environment.
@@ -234,6 +288,7 @@ LoadData <- function(opt_list) {
         stop('Genotype file is missing')
     }
      
+    cis_distance <- as.numeric(opt_list$cisdistance)
     expression_matrix = fread(opt_list$expression_matrix,header = TRUE) %>% dplyr::rename('phenotype_id' = 4)
     subset_matrix <- expression_matrix %>% select(1,2,3,4)
     print(colnames(subset_matrix))
@@ -266,6 +321,7 @@ LoadData <- function(opt_list) {
         mutate(gene_id = phenotype_id,group_id = phenotype_id) %>%
         select(phenotype_id,group_id,gene_id,chromosome,phenotype_pos,phenotype_start,phenotype_end,strand)
     expanded_interval_count <- sum(
+        phenotype_meta$phenotype_id != "skip" &
         !is.na(phenotype_meta$phenotype_start) &
         !is.na(phenotype_meta$phenotype_end) &
         (phenotype_meta$phenotype_end - phenotype_meta$phenotype_start) > 1
@@ -277,6 +333,7 @@ LoadData <- function(opt_list) {
             " phenotype BED intervals wider than 1 bp; using interval midpoint as the feature coordinate"
         )
     }
+    validatePreparedWindowCoverage(phenotype_meta, cis_distance)
     # Convert the sample list into the sample metadata shape required by
     # eQTLUtils; CV workflows can omit this because metadata is stored in CV RDS.
     message('Loading sample metadata')
@@ -348,7 +405,6 @@ LoadData <- function(opt_list) {
     # Collect scalar inputs and optional filters in a single output list for the
     # entrypoint scripts.
     genotype_file <- opt_list$genotype_matrix
-    cis_distance <- as.numeric(opt_list$cisdistance)
     output_prefix <- opt_list$out_prefix
     n_folds <- opt_list$n_folds
     variant_list <- opt_list$VariantList

--- a/R/utils/OptParser.R
+++ b/R/utils/OptParser.R
@@ -26,7 +26,7 @@ option_list <- list(
   optparse::make_option(c("--qtl_group"), type="character", default=NULL,
     help="Value of the current qtl_group", metavar="type"),
   optparse::make_option(c("--cisdistance"), type="integer", default=1000000,
-    help="Cis distance (bp) from center of gene [default \"%default\"]", metavar="number"),
+    help="Cis distance (bp) added to each side of the phenotype BED interval midpoint [default \"%default\"]", metavar="number"),
   optparse::make_option(c("--reuse_genotype_matrix"), type="logical", default=FALSE,
     help="If true, reuse one residualized genotype matrix when selected phenotype windows merge into one region [default \"%default\"]", metavar="type"),
   optparse::make_option(c("--select_top_phenotype_per_cluster"), type="logical", default=FALSE,

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -9,6 +9,8 @@ These inputs are shared across the main fine-mapping workflows.
 | `TensorQTLPermutations` | Permutation p-values output from tensorQTL. |
 | `PhenotypeBed` | BED file for the gene or phenotype to be fine-mapped. The fine-mapping scripts use the midpoint of columns 2-3 as the feature coordinate. |
 | `CisDistance` | Window in bp added to each side of the phenotype BED interval midpoint for fine-mapping. |
+| `WindowSize` | Window in bp added to each side of the phenotype BED interval midpoint during prep input extraction. Use `WindowSize >= CisDistance` when running fine-mapping from prepared dosages. |
+| `PreparedWindowSize` | Optional fine-mapping-only guard for pre-subset dosage inputs. Set this to the prep `WindowSize` to fail early when `CisDistance` asks for variants outside the prepared dosage window. |
 | `PhenotypeID` | Legacy single phenotype ID. When substring matching is used, this is used as the output prefix and gene ID to match within splice-junction phenotype IDs. |
 | `MatchPhenotypeIDSubstring` | If `true`, select all phenotype IDs containing `PhenotypeID`. Use for splice-junction IDs that embed the gene ID. |
 | `ReuseGenotypeMatrix` | If `true`, reuse one residualized genotype matrix when selected phenotype windows merge into a single region. |

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -7,8 +7,8 @@ These inputs are shared across the main fine-mapping workflows.
 | `GenotypeDosages` | Genotype dosage file. Can be generated from a VCF using `bcftools dose`. |
 | `GenotypeDosageIndex` | Tabix `.tbi` index for the dosage file. |
 | `TensorQTLPermutations` | Permutation p-values output from tensorQTL. |
-| `PhenotypeBed` | BED file for the gene or phenotype to be fine-mapped. |
-| `CisDistance` | Window in bp added to each side of the TSS for fine-mapping. |
+| `PhenotypeBed` | BED file for the gene or phenotype to be fine-mapped. The fine-mapping scripts use the midpoint of columns 2-3 as the feature coordinate. |
+| `CisDistance` | Window in bp added to each side of the phenotype BED interval midpoint for fine-mapping. |
 | `PhenotypeID` | Legacy single phenotype ID. When substring matching is used, this is used as the output prefix and gene ID to match within splice-junction phenotype IDs. |
 | `MatchPhenotypeIDSubstring` | If `true`, select all phenotype IDs containing `PhenotypeID`. Use for splice-junction IDs that embed the gene ID. |
 | `ReuseGenotypeMatrix` | If `true`, reuse one residualized genotype matrix when selected phenotype windows merge into a single region. |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -4,7 +4,7 @@ The workflow entrypoint scripts live in `R/scripts/`. Shared helper functions li
 
 ## `R/scripts/susie.R`
 
-The main fine-mapping script. It loads genotype dosages, expression or phenotype data, covariates, and a list of phenotypes to fine-map, then runs susieR on each phenotype in the provided cis window.
+The main fine-mapping script. It loads genotype dosages, expression or phenotype data, covariates, and a list of phenotypes to fine-map, then runs susieR on each phenotype in the provided cis window. The feature coordinate is the midpoint of the phenotype BED interval, so 1 bp site/TSS intervals and already-expanded phenotype windows are centered consistently.
 
 Results are written to three Parquet files plus one variant-position diagnostic TSV:
 
@@ -20,12 +20,12 @@ Key command-line arguments:
 | Argument | Description |
 |---|---|
 | `--genotype_matrix` | Tabix-indexed genotype dosage file. |
-| `--expression_matrix` | BED-format phenotype or expression file. |
+| `--expression_matrix` | BED-format phenotype or expression file. Columns 2-3 are converted to a midpoint feature coordinate before cis-window expansion. |
 | `--phenotype_list` | TensorQTL permutation output that defines phenotypes to fine-map. |
 | `--covariates` | Covariate matrix used in QTL calling. |
 | `--sample_meta` | List of sample IDs to include. |
 | `--out_prefix` | Output file prefix. |
-| `--cisdistance` | Cis window in bp added to each side of the TSS. |
+| `--cisdistance` | Cis window in bp added to each side of the phenotype BED interval midpoint. |
 | `--reuse_genotype_matrix` | Reuse one residualized genotype matrix when selected phenotype windows merge into one region. |
 | `--select_top_phenotype_per_cluster` | Fine-map only the strongest FDR-passing phenotype per parsed LeafCutter `clu_*` cluster. |
 | `--top_phenotype_pvalue_column` | Preferred TensorQTL p-value column for choosing the representative phenotype per cluster. Defaults to `qval`. |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -29,6 +29,7 @@ Runs both input preparation and fine-mapping in a single workflow. First calls `
 | `TensorQTLPermutations` | File | Permutation p-values output from tensorQTL. |
 | `PhenotypeBed` | File | BED file for the gene or phenotype to be fine-mapped. Prep and fine-mapping center windows on the midpoint of columns 2-3. |
 | `CisDistance` | Int | Window size in bp added to each side of the phenotype BED interval midpoint. |
+| `WindowSize` | Int | Prep extraction window in bp added to each side of the phenotype BED interval midpoint. Defaults to `1000000`; the workflow fails if `CisDistance > WindowSize`. |
 | `PhenotypeID` | String | Legacy single phenotype ID. When substring matching is used, this becomes the output prefix and gene ID to match within splice-junction phenotype IDs. |
 | `MatchPhenotypeIDSubstring` | Boolean | If `true`, select all phenotype IDs containing `PhenotypeID`. This supports splice-junction IDs that embed the gene ID. |
 | `ReuseGenotypeMatrix` | Boolean | If `true`, reuse one residualized genotype matrix when selected phenotype windows merge into a single region. |
@@ -65,6 +66,7 @@ Optional inputs in addition to the shared fine-mapping inputs:
 | `ReuseGenotypeMatrix` | Boolean | If `true`, reuse one residualized genotype matrix when selected phenotype windows merge into a single region. |
 | `SelectTopPhenotypePerCluster` | Boolean | If `true`, reduce selected phenotypes to the strongest FDR-passing intron per parsed LeafCutter `clu_*` cluster. |
 | `TopPhenotypePerClusterPvalueColumn` | String | Preferred TensorQTL p-value column used to choose the representative intron. |
+| `PreparedWindowSize` | Int | Optional guard for pre-subset dosage inputs. Set to the prep `WindowSize`; values below `CisDistance` stop the task before fine-mapping. Defaults to `-1`, which disables the shell guard. |
 | `VariantList` | File? | Single-column file of variants formatted as `chr_pos_ref_alt` to restrict analysis. |
 | `AncestryFile` | File? | Ancestry metadata for per-population MAF filtering. |
 | `AdditionalGenotypesBed` | File? | Additional genotype BED file. |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -27,8 +27,8 @@ Runs both input preparation and fine-mapping in a single workflow. First calls `
 | `GenotypeDosages` | File | Tabix-indexed genotype dosage file, which can be generated from VCF using `bcftools dose`. |
 | `GenotypeDosageIndex` | File | Tabix `.tbi` index for the dosage file. |
 | `TensorQTLPermutations` | File | Permutation p-values output from tensorQTL. |
-| `PhenotypeBed` | File | BED file for the gene or phenotype to be fine-mapped. |
-| `CisDistance` | Int | Window size in bp added to each side of the TSS. |
+| `PhenotypeBed` | File | BED file for the gene or phenotype to be fine-mapped. Prep and fine-mapping center windows on the midpoint of columns 2-3. |
+| `CisDistance` | Int | Window size in bp added to each side of the phenotype BED interval midpoint. |
 | `PhenotypeID` | String | Legacy single phenotype ID. When substring matching is used, this becomes the output prefix and gene ID to match within splice-junction phenotype IDs. |
 | `MatchPhenotypeIDSubstring` | Boolean | If `true`, select all phenotype IDs containing `PhenotypeID`. This supports splice-junction IDs that embed the gene ID. |
 | `ReuseGenotypeMatrix` | Boolean | If `true`, reuse one residualized genotype matrix when selected phenotype windows merge into a single region. |
@@ -93,7 +93,7 @@ Extracts phenotype rows and matching TensorQTL permutation rows for multi-phenot
 
 ### `workflows/prepInputsSusieR.wdl` - Input Preparation Only
 
-Subsets genotype dosages, the phenotype BED file, and TensorQTL permutation results to the region surrounding `PhenotypeID`, or all phenotype IDs containing `PhenotypeID` when `MatchPhenotypeIDSubstring` is true. This is the first step of `workflows/susieR.wdl` exposed as a standalone workflow, useful for preparing inputs once before running fine-mapping multiple times. It always prepares all matched rows; representative intron-per-cluster selection happens later in fine-mapping.
+Subsets genotype dosages, the phenotype BED file, and TensorQTL permutation results to the region surrounding `PhenotypeID`, or all phenotype IDs containing `PhenotypeID` when `MatchPhenotypeIDSubstring` is true. Prep windows are centered on the midpoint of each matched phenotype BED interval before adding `WindowSize` on each side. This is the first step of `workflows/susieR.wdl` exposed as a standalone workflow, useful for preparing inputs once before running fine-mapping multiple times. It always prepares all matched rows; representative intron-per-cluster selection happens later in fine-mapping.
 
 | Output | Description |
 |---|---|

--- a/workflows/prepInputsSusieR.wdl
+++ b/workflows/prepInputsSusieR.wdl
@@ -34,11 +34,11 @@ task PrepInputs {
         : > feature_sites.tsv
         if [ "~{phenotype_match_mode}" = "contains" ]; then
             zcat "~{PhenotypeBed}" \
-                | awk -v needle="~{PhenotypeID}" -v window_size=~{WindowSize} 'BEGIN{OFS="\t"} FNR == 1 && $4 == "phenotype_id" {next} index($4, needle) > 0 {feature_pos=$2; window_start=$2-window_size; window_end=$3+window_size; if(window_start<1) window_start=1; print $4,$1,feature_pos,window_start,window_end,window_end-window_start+1 >> "feature_sites.tsv"; $2=window_start; $3=window_end; print}' \
+                | awk -v needle="~{PhenotypeID}" -v window_size=~{WindowSize} 'BEGIN{OFS="\t"} FNR == 1 && $4 == "phenotype_id" {next} index($4, needle) > 0 {feature_pos=int((($2+0)+($3+0))/2); window_start=feature_pos-window_size; window_end=feature_pos+window_size+1; if(window_start<1) window_start=1; print $4,$1,feature_pos,window_start,window_end,window_end-window_start+1 >> "feature_sites.tsv"; $2=window_start; $3=window_end; print}' \
                 > feature.bed
         else
             zcat "~{PhenotypeBed}" \
-                | awk -v phenotype_id="~{PhenotypeID}" -v window_size=~{WindowSize} 'BEGIN{OFS="\t"} FNR == 1 && $4 == "phenotype_id" {next} $4 == phenotype_id {feature_pos=$2; window_start=$2-window_size; window_end=$3+window_size; if(window_start<1) window_start=1; print $4,$1,feature_pos,window_start,window_end,window_end-window_start+1 >> "feature_sites.tsv"; $2=window_start; $3=window_end; print}' \
+                | awk -v phenotype_id="~{PhenotypeID}" -v window_size=~{WindowSize} 'BEGIN{OFS="\t"} FNR == 1 && $4 == "phenotype_id" {next} $4 == phenotype_id {feature_pos=int((($2+0)+($3+0))/2); window_start=feature_pos-window_size; window_end=feature_pos+window_size+1; if(window_start<1) window_start=1; print $4,$1,feature_pos,window_start,window_end,window_end-window_start+1 >> "feature_sites.tsv"; $2=window_start; $3=window_end; print}' \
                 > feature.bed
         fi
         if [ ! -s feature.bed ]; then

--- a/workflows/susieR.wdl
+++ b/workflows/susieR.wdl
@@ -55,11 +55,11 @@ task PrepInputs {
         : > feature_sites.tsv
         if [ "~{phenotype_match_mode}" = "contains" ]; then
             zcat "~{PhenotypeBed}" \
-                | awk -v needle="~{PhenotypeID}" -v window_size=1000000 'BEGIN{OFS="\t"} FNR == 1 && $4 == "phenotype_id" {next} index($4, needle) > 0 {feature_pos=$2; window_start=$2-window_size; window_end=$3+window_size; if(window_start<1) window_start=1; print $4,$1,feature_pos,window_start,window_end,window_end-window_start+1 >> "feature_sites.tsv"; $2=window_start; $3=window_end; print}' \
+                | awk -v needle="~{PhenotypeID}" -v window_size=1000000 'BEGIN{OFS="\t"} FNR == 1 && $4 == "phenotype_id" {next} index($4, needle) > 0 {feature_pos=int((($2+0)+($3+0))/2); window_start=feature_pos-window_size; window_end=feature_pos+window_size+1; if(window_start<1) window_start=1; print $4,$1,feature_pos,window_start,window_end,window_end-window_start+1 >> "feature_sites.tsv"; $2=window_start; $3=window_end; print}' \
                 > feature.bed
         else
             zcat "~{PhenotypeBed}" \
-                | awk -v phenotype_id="~{PhenotypeID}" -v window_size=1000000 'BEGIN{OFS="\t"} FNR == 1 && $4 == "phenotype_id" {next} $4 == phenotype_id {feature_pos=$2; window_start=$2-window_size; window_end=$3+window_size; if(window_start<1) window_start=1; print $4,$1,feature_pos,window_start,window_end,window_end-window_start+1 >> "feature_sites.tsv"; $2=window_start; $3=window_end; print}' \
+                | awk -v phenotype_id="~{PhenotypeID}" -v window_size=1000000 'BEGIN{OFS="\t"} FNR == 1 && $4 == "phenotype_id" {next} $4 == phenotype_id {feature_pos=int((($2+0)+($3+0))/2); window_start=feature_pos-window_size; window_end=feature_pos+window_size+1; if(window_start<1) window_start=1; print $4,$1,feature_pos,window_start,window_end,window_end-window_start+1 >> "feature_sites.tsv"; $2=window_start; $3=window_end; print}' \
                 > feature.bed
         fi
         if [ ! -s feature.bed ]; then

--- a/workflows/susieR.wdl
+++ b/workflows/susieR.wdl
@@ -32,6 +32,7 @@ task PrepInputs {
         File PhenotypeBed
         File TensorQTLPermutations
         Int NumPrempt
+        Int WindowSize = 1000000
     }
     String phenotype_match_mode = if MatchPhenotypeIDSubstring then "contains" else "exact"
 
@@ -55,11 +56,11 @@ task PrepInputs {
         : > feature_sites.tsv
         if [ "~{phenotype_match_mode}" = "contains" ]; then
             zcat "~{PhenotypeBed}" \
-                | awk -v needle="~{PhenotypeID}" -v window_size=1000000 'BEGIN{OFS="\t"} FNR == 1 && $4 == "phenotype_id" {next} index($4, needle) > 0 {feature_pos=int((($2+0)+($3+0))/2); window_start=feature_pos-window_size; window_end=feature_pos+window_size+1; if(window_start<1) window_start=1; print $4,$1,feature_pos,window_start,window_end,window_end-window_start+1 >> "feature_sites.tsv"; $2=window_start; $3=window_end; print}' \
+                | awk -v needle="~{PhenotypeID}" -v window_size=~{WindowSize} 'BEGIN{OFS="\t"} FNR == 1 && $4 == "phenotype_id" {next} index($4, needle) > 0 {feature_pos=int((($2+0)+($3+0))/2); window_start=feature_pos-window_size; window_end=feature_pos+window_size+1; if(window_start<1) window_start=1; print $4,$1,feature_pos,window_start,window_end,window_end-window_start+1 >> "feature_sites.tsv"; $2=window_start; $3=window_end; print}' \
                 > feature.bed
         else
             zcat "~{PhenotypeBed}" \
-                | awk -v phenotype_id="~{PhenotypeID}" -v window_size=1000000 'BEGIN{OFS="\t"} FNR == 1 && $4 == "phenotype_id" {next} $4 == phenotype_id {feature_pos=int((($2+0)+($3+0))/2); window_start=feature_pos-window_size; window_end=feature_pos+window_size+1; if(window_start<1) window_start=1; print $4,$1,feature_pos,window_start,window_end,window_end-window_start+1 >> "feature_sites.tsv"; $2=window_start; $3=window_end; print}' \
+                | awk -v phenotype_id="~{PhenotypeID}" -v window_size=~{WindowSize} 'BEGIN{OFS="\t"} FNR == 1 && $4 == "phenotype_id" {next} $4 == phenotype_id {feature_pos=int((($2+0)+($3+0))/2); window_start=feature_pos-window_size; window_end=feature_pos+window_size+1; if(window_start<1) window_start=1; print $4,$1,feature_pos,window_start,window_end,window_end-window_start+1 >> "feature_sites.tsv"; $2=window_start; $3=window_end; print}' \
                 > feature.bed
         fi
         if [ ! -s feature.bed ]; then
@@ -147,12 +148,19 @@ task susieR {
         Int memory
         Int NumPrempt
         Float MAF
+        Int PreparedWindowSize = -1
         Boolean ReuseGenotypeMatrix = false
         Boolean SelectTopPhenotypePerCluster = false
         String TopPhenotypePerClusterPvalueColumn = "qval"
     }
 
     command <<<
+        if [ ~{PreparedWindowSize} -ge 0 ] && [ ~{CisDistance} -gt ~{PreparedWindowSize} ]; then
+            echo "CisDistance (~{CisDistance}) is larger than the prepared dosage WindowSize (~{PreparedWindowSize}); prepared dosages may not contain all requested variants." >&2
+            echo "Re-run PrepInputs with WindowSize >= CisDistance or reduce CisDistance." >&2
+            exit 1
+        fi
+
         Rscript ~{susie_rscript} ~{if ReuseGenotypeMatrix then "--reuse_genotype_matrix true" else ""} ~{if SelectTopPhenotypePerCluster then "--select_top_phenotype_per_cluster true --top_phenotype_pvalue_column " else ""}~{if SelectTopPhenotypePerCluster then TopPhenotypePerClusterPvalueColumn else ""} \
             --MAF ~{MAF} \
             --genotype_matrix ~{GenotypeDosages} \
@@ -235,6 +243,7 @@ workflow SusieRWorkflow {
         Boolean ReuseGenotypeMatrix = false
         Boolean SelectTopPhenotypePerCluster = false
         String TopPhenotypePerClusterPvalueColumn = "qval"
+        Int WindowSize = 1000000
     }
 
     call PrepInputs {
@@ -245,7 +254,8 @@ workflow SusieRWorkflow {
             GenotypeDosages = GenotypeDosages,
             GenotypeDosageIndex = GenotypeDosageIndex,
             PhenotypeBed = PhenotypeBed,
-            NumPrempt = NumPrempt
+            NumPrempt = NumPrempt,
+            WindowSize = WindowSize
     }
 
     call susieR {
@@ -262,6 +272,7 @@ workflow SusieRWorkflow {
             memory = memory,
             NumPrempt = NumPrempt,
             MAF = MAF,
+            PreparedWindowSize = WindowSize,
             ReuseGenotypeMatrix = ReuseGenotypeMatrix,
             SelectTopPhenotypePerCluster = SelectTopPhenotypePerCluster,
             TopPhenotypePerClusterPvalueColumn = TopPhenotypePerClusterPvalueColumn

--- a/workflows/susieRonly.wdl
+++ b/workflows/susieRonly.wdl
@@ -18,6 +18,7 @@ task susieR {
         Boolean ReuseGenotypeMatrix = false
         Boolean SelectTopPhenotypePerCluster = false
         String TopPhenotypePerClusterPvalueColumn = "qval"
+        Int PreparedWindowSize = -1
         File? VariantList
         File? AncestryFile
         File? AdditionalGenotypesBed
@@ -44,6 +45,12 @@ task susieR {
         fi
         head -n 1 input_gene.txt | awk -F'\t' 'BEGIN{OFS="\t"} {$4="skip"; print}' > skip.txt        
         cat header.txt input_gene.txt skip.txt > input_gene.bed  
+
+        if [ ~{PreparedWindowSize} -ge 0 ] && [ ~{CisDistance} -gt ~{PreparedWindowSize} ]; then
+            echo "CisDistance (~{CisDistance}) is larger than the prepared dosage WindowSize (~{PreparedWindowSize}); prepared dosages may not contain all requested variants." >&2
+            echo "Re-run PrepInputs with WindowSize >= CisDistance or reduce CisDistance." >&2
+            exit 1
+        fi
 
         Rscript /tmp/susie.R ~{if defined(MAF) then "--MAF ~{MAF}  " else ""} ~{if ReuseGenotypeMatrix then "--reuse_genotype_matrix true  " else ""} ~{if SelectTopPhenotypePerCluster then "--select_top_phenotype_per_cluster true --top_phenotype_pvalue_column " else ""}~{if SelectTopPhenotypePerCluster then TopPhenotypePerClusterPvalueColumn else ""} ~{if defined(AncestryFile) then "--AncestryMetadata ~{AncestryFile}  "  else ""} ~{if defined(VariantList) then "--VariantList ~{VariantList}  "  else ""}  ~{if defined(AdditionalGenotypesBed) then "--AdditionalGenotypesBed ~{AdditionalGenotypesBed}  "  else ""} \
             --genotype_matrix ~{GenotypeDosages} \
@@ -92,6 +99,7 @@ workflow SusieROnlyWorkflow {
         Boolean ReuseGenotypeMatrix = false
         Boolean SelectTopPhenotypePerCluster = false
         String TopPhenotypePerClusterPvalueColumn = "qval"
+        Int PreparedWindowSize = -1
         File? VariantList
         File? AncestryFile
         File? AdditionalGenotypesBed
@@ -113,6 +121,7 @@ workflow SusieROnlyWorkflow {
             ReuseGenotypeMatrix = ReuseGenotypeMatrix,
             SelectTopPhenotypePerCluster = SelectTopPhenotypePerCluster,
             TopPhenotypePerClusterPvalueColumn = TopPhenotypePerClusterPvalueColumn,
+            PreparedWindowSize = PreparedWindowSize,
             VariantList = VariantList,
             AncestryFile = AncestryFile,
             AdditionalGenotypesBed = AdditionalGenotypesBed


### PR DESCRIPTION
## Summary

- Use the midpoint of BED columns 2-3 as the phenotype feature coordinate in the shared R loader.
- Center PrepInputs dosage extraction on the same BED midpoint before applying WindowSize.
- Update docs and CLI help to describe midpoint-centered cis windows.

## Validation

- bash tools/validate_repo.sh
- Sanity checked the example editing BED maps to feature_pos=100924266 and window 100824266-101024267 with a 100 kb window.