### PR TITLE
Simplify full susie workflow inputs

### DIFF
--- a/R/utils/ImportFunctions.R
+++ b/R/utils/ImportFunctions.R
@@ -214,60 +214,6 @@ reportPhenotypeMatchDiagnostics <- function(requested_phenotype_id,
     invisible(NULL)
 }
 
-validatePreparedWindowCoverage <- function(phenotype_meta, cis_distance, max_examples = 5) {
-    if (is.null(cis_distance) || is.na(cis_distance) || cis_distance <= 0) {
-        return(invisible(NULL))
-    }
-
-    windowed_meta <- phenotype_meta %>%
-        dplyr::filter(
-            phenotype_id != "skip",
-            !is.na(phenotype_start),
-            !is.na(phenotype_end),
-            (phenotype_end - phenotype_start) > 1
-        ) %>%
-        dplyr::mutate(
-            requested_start = pmax(1, phenotype_pos - cis_distance),
-            requested_end = phenotype_pos + cis_distance + 1,
-            missing_requested_window = phenotype_start > requested_start | phenotype_end < requested_end
-        ) %>%
-        dplyr::filter(missing_requested_window)
-
-    if (nrow(windowed_meta) == 0) {
-        return(invisible(NULL))
-    }
-
-    examples <- windowed_meta %>%
-        utils::head(max_examples) %>%
-        dplyr::transmute(
-            detail = paste0(
-                phenotype_id,
-                " available ",
-                chromosome,
-                ":",
-                phenotype_start,
-                "-",
-                phenotype_end,
-                ", requested ",
-                chromosome,
-                ":",
-                requested_start,
-                "-",
-                requested_end,
-                ", feature midpoint ",
-                phenotype_pos
-            )
-        ) %>%
-        dplyr::pull(detail)
-
-    stop(
-        "Requested CisDistance is larger than at least one prepared phenotype BED interval. ",
-        "This can drop variants from pre-subset dosage files. ",
-        "Re-run PrepInputs with WindowSize >= CisDistance or reduce CisDistance. Examples: ",
-        paste(examples, collapse = " | ")
-    )
-}
-
 # Main data loader used by susie.R and ComputeR2Susie.R. It validates required
 # inputs, loads molecular/covariate/QTL data, and returns a named list that is
 # injected into the caller environment.
@@ -288,7 +234,6 @@ LoadData <- function(opt_list) {
         stop('Genotype file is missing')
     }
      
-    cis_distance <- as.numeric(opt_list$cisdistance)
     expression_matrix = fread(opt_list$expression_matrix,header = TRUE) %>% dplyr::rename('phenotype_id' = 4)
     subset_matrix <- expression_matrix %>% select(1,2,3,4)
     print(colnames(subset_matrix))
@@ -333,7 +278,6 @@ LoadData <- function(opt_list) {
             " phenotype BED intervals wider than 1 bp; using interval midpoint as the feature coordinate"
         )
     }
-    validatePreparedWindowCoverage(phenotype_meta, cis_distance)
     # Convert the sample list into the sample metadata shape required by
     # eQTLUtils; CV workflows can omit this because metadata is stored in CV RDS.
     message('Loading sample metadata')
@@ -405,6 +349,7 @@ LoadData <- function(opt_list) {
     # Collect scalar inputs and optional filters in a single output list for the
     # entrypoint scripts.
     genotype_file <- opt_list$genotype_matrix
+    cis_distance <- as.numeric(opt_list$cisdistance)
     output_prefix <- opt_list$out_prefix
     n_folds <- opt_list$n_folds
     variant_list <- opt_list$VariantList

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -8,8 +8,8 @@ These inputs are shared across the main fine-mapping workflows.
 | `GenotypeDosageIndex` | Tabix `.tbi` index for the dosage file. |
 | `TensorQTLPermutations` | Permutation p-values output from tensorQTL. |
 | `PhenotypeBed` | BED file for the gene or phenotype to be fine-mapped. The fine-mapping scripts use the midpoint of columns 2-3 as the feature coordinate. |
-| `CisDistance` | Window in bp added to each side of the phenotype BED interval midpoint for fine-mapping. |
-| `WindowSize` | Window in bp added to each side of the phenotype BED interval midpoint during prep input extraction. Use `WindowSize >= CisDistance` when running fine-mapping from prepared dosages. |
+| `CisDistance` | Window in bp added to each side of the phenotype BED interval midpoint for fine-mapping. In the full workflow, this same value is used for prep extraction. |
+| `WindowSize` | Standalone prep-only window in bp added to each side of the phenotype BED interval midpoint. |
 | `PreparedWindowSize` | Optional fine-mapping-only guard for pre-subset dosage inputs. Set this to the prep `WindowSize` to fail early when `CisDistance` asks for variants outside the prepared dosage window. |
 | `PhenotypeID` | Legacy single phenotype ID. When substring matching is used, this is used as the output prefix and gene ID to match within splice-junction phenotype IDs. |
 | `MatchPhenotypeIDSubstring` | If `true`, select all phenotype IDs containing `PhenotypeID`. Use for splice-junction IDs that embed the gene ID. |

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -23,6 +23,6 @@ These inputs are shared across the main fine-mapping workflows.
 
 | Input | Description |
 |---|---|
-| `MAF` | Float MAF cutoff for variants. Requires `AncestryMetadata`. MAF is calculated per population and a variant must pass the cutoff in at least one population. Individuals not assigned to any population are excluded from the MAF calculation. |
+| `MAF` | Optional float MAF cutoff for variants. Defaults to `0`. Requires `AncestryMetadata` when greater than `0`. MAF is calculated per population and a variant must pass the cutoff in at least one population. Individuals not assigned to any population are excluded from the MAF calculation. |
 | `AncestryMetadata` | Ancestry metadata file. Requires a column named `ancestry_pred_oth` for population assignment. |
 | `VariantList` | Single-column file of variants formatted as `chr_pos_ref_alt`. Restricts analysis to listed variants and takes precedence over `MAF` filtering. |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -20,7 +20,7 @@ Template input JSONs live in [`../examples/inputs/`](../examples/inputs/). They 
 
 ### `workflows/susieR.wdl` - Full Pipeline
 
-Runs both input preparation and fine-mapping in a single workflow. First calls `PrepInputs` to subset all input files to the region around the target phenotype, then calls `susieR` to perform fine-mapping on those subsetted files. Representative intron-per-cluster selection is applied inside `susie.R` during fine-mapping, not by the WDL prep shell code.
+Runs both input preparation and fine-mapping in a single workflow. First calls `PrepInputs` to subset all input files to the `CisDistance` region around the target phenotype, then calls `susieR` to perform fine-mapping on those subsetted files. Representative intron-per-cluster selection is applied inside `susie.R` during fine-mapping, not by the WDL prep shell code.
 
 | Input | Type | Description |
 |---|---|---|
@@ -28,8 +28,7 @@ Runs both input preparation and fine-mapping in a single workflow. First calls `
 | `GenotypeDosageIndex` | File | Tabix `.tbi` index for the dosage file. |
 | `TensorQTLPermutations` | File | Permutation p-values output from tensorQTL. |
 | `PhenotypeBed` | File | BED file for the gene or phenotype to be fine-mapped. Prep and fine-mapping center windows on the midpoint of columns 2-3. |
-| `CisDistance` | Int | Window size in bp added to each side of the phenotype BED interval midpoint. |
-| `WindowSize` | Int | Prep extraction window in bp added to each side of the phenotype BED interval midpoint. Defaults to `1000000`; the workflow fails if `CisDistance > WindowSize`. |
+| `CisDistance` | Int | Window size in bp added to each side of the phenotype BED interval midpoint for both prep extraction and fine-mapping. |
 | `PhenotypeID` | String | Legacy single phenotype ID. When substring matching is used, this becomes the output prefix and gene ID to match within splice-junction phenotype IDs. |
 | `MatchPhenotypeIDSubstring` | Boolean | If `true`, select all phenotype IDs containing `PhenotypeID`. This supports splice-junction IDs that embed the gene ID. |
 | `ReuseGenotypeMatrix` | Boolean | If `true`, reuse one residualized genotype matrix when selected phenotype windows merge into a single region. |
@@ -37,7 +36,6 @@ Runs both input preparation and fine-mapping in a single workflow. First calls `
 | `TopPhenotypePerClusterPvalueColumn` | String | Preferred TensorQTL p-value column used to choose the representative intron. Defaults to `qval`. |
 | `QTLCovariates` | File | Covariate table used in QTL calling. |
 | `SampleList` | File | Sample IDs used in fine-mapping. Requires a header. |
-| `susie_rscript` | File | Path to the `susie.R` script. |
 | `memory` | Int | Memory in GB for the fine-mapping task. |
 | `NumPrempt` | Int | Number of preemptible retries. |
 | `MAF` | Float | Minor allele frequency cutoff. Pass `0` to include all variants. |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -38,7 +38,7 @@ Runs both input preparation and fine-mapping in a single workflow. First calls `
 | `SampleList` | File | Sample IDs used in fine-mapping. Requires a header. |
 | `memory` | Int | Memory in GB for the fine-mapping task. |
 | `NumPrempt` | Int | Number of preemptible retries. |
-| `MAF` | Float | Minor allele frequency cutoff. Pass `0` to include all variants. |
+| `MAF` | Float | Optional minor allele frequency cutoff. Defaults to `0`, which includes all variants. |
 
 | Output | Description |
 |---|---|

--- a/examples/inputs/susieR.inputs.json
+++ b/examples/inputs/susieR.inputs.json
@@ -6,7 +6,6 @@
   "SusieRWorkflow.SampleList": "gs://bucket/path/sample_list.tsv",
   "SusieRWorkflow.PhenotypeBed": "gs://bucket/path/phenotypes.bed.gz",
   "SusieRWorkflow.CisDistance": 1000000,
-  "SusieRWorkflow.susie_rscript": "gs://bucket/path/susie.R",
   "SusieRWorkflow.memory": 16,
   "SusieRWorkflow.NumPrempt": 2,
   "SusieRWorkflow.PhenotypeID": "phenotype_id",

--- a/examples/inputs/susieR.inputs.json
+++ b/examples/inputs/susieR.inputs.json
@@ -8,6 +8,5 @@
   "SusieRWorkflow.CisDistance": 1000000,
   "SusieRWorkflow.memory": 16,
   "SusieRWorkflow.NumPrempt": 2,
-  "SusieRWorkflow.PhenotypeID": "phenotype_id",
-  "SusieRWorkflow.MAF": 0.01
+  "SusieRWorkflow.PhenotypeID": "phenotype_id"
 }

--- a/workflows/susieR.wdl
+++ b/workflows/susieR.wdl
@@ -146,7 +146,7 @@ task susieR {
         String OutputPrefix
         Int memory
         Int NumPrempt
-        Float MAF
+        Float MAF = 0.0
         Boolean ReuseGenotypeMatrix = false
         Boolean SelectTopPhenotypePerCluster = false
         String TopPhenotypePerClusterPvalueColumn = "qval"
@@ -230,7 +230,7 @@ workflow SusieRWorkflow {
         Int NumPrempt
         String PhenotypeID
         Boolean MatchPhenotypeIDSubstring = false
-        Float MAF
+        Float MAF = 0.0
         Boolean ReuseGenotypeMatrix = false
         Boolean SelectTopPhenotypePerCluster = false
         String TopPhenotypePerClusterPvalueColumn = "qval"

--- a/workflows/susieR.wdl
+++ b/workflows/susieR.wdl
@@ -144,24 +144,16 @@ task susieR {
         File PhenotypeBed
         Int CisDistance
         String OutputPrefix
-        File susie_rscript
         Int memory
         Int NumPrempt
         Float MAF
-        Int PreparedWindowSize = -1
         Boolean ReuseGenotypeMatrix = false
         Boolean SelectTopPhenotypePerCluster = false
         String TopPhenotypePerClusterPvalueColumn = "qval"
     }
 
     command <<<
-        if [ ~{PreparedWindowSize} -ge 0 ] && [ ~{CisDistance} -gt ~{PreparedWindowSize} ]; then
-            echo "CisDistance (~{CisDistance}) is larger than the prepared dosage WindowSize (~{PreparedWindowSize}); prepared dosages may not contain all requested variants." >&2
-            echo "Re-run PrepInputs with WindowSize >= CisDistance or reduce CisDistance." >&2
-            exit 1
-        fi
-
-        Rscript ~{susie_rscript} ~{if ReuseGenotypeMatrix then "--reuse_genotype_matrix true" else ""} ~{if SelectTopPhenotypePerCluster then "--select_top_phenotype_per_cluster true --top_phenotype_pvalue_column " else ""}~{if SelectTopPhenotypePerCluster then TopPhenotypePerClusterPvalueColumn else ""} \
+        Rscript /tmp/susie.R ~{if ReuseGenotypeMatrix then "--reuse_genotype_matrix true" else ""} ~{if SelectTopPhenotypePerCluster then "--select_top_phenotype_per_cluster true --top_phenotype_pvalue_column " else ""}~{if SelectTopPhenotypePerCluster then TopPhenotypePerClusterPvalueColumn else ""} \
             --MAF ~{MAF} \
             --genotype_matrix ~{GenotypeDosages} \
             --sample_meta ~{SampleList} \
@@ -234,7 +226,6 @@ workflow SusieRWorkflow {
         File SampleList
         File PhenotypeBed
         Int CisDistance
-        File susie_rscript
         Int memory
         Int NumPrempt
         String PhenotypeID
@@ -243,7 +234,6 @@ workflow SusieRWorkflow {
         Boolean ReuseGenotypeMatrix = false
         Boolean SelectTopPhenotypePerCluster = false
         String TopPhenotypePerClusterPvalueColumn = "qval"
-        Int WindowSize = 1000000
     }
 
     call PrepInputs {
@@ -255,7 +245,7 @@ workflow SusieRWorkflow {
             GenotypeDosageIndex = GenotypeDosageIndex,
             PhenotypeBed = PhenotypeBed,
             NumPrempt = NumPrempt,
-            WindowSize = WindowSize
+            WindowSize = CisDistance
     }
 
     call susieR {
@@ -268,11 +258,9 @@ workflow SusieRWorkflow {
             PhenotypeBed = PhenotypeBed ,
             CisDistance = CisDistance,
             OutputPrefix = PhenotypeID,
-            susie_rscript = susie_rscript,
             memory = memory,
             NumPrempt = NumPrempt,
             MAF = MAF,
-            PreparedWindowSize = WindowSize,
             ReuseGenotypeMatrix = ReuseGenotypeMatrix,
             SelectTopPhenotypePerCluster = SelectTopPhenotypePerCluster,
             TopPhenotypePerClusterPvalueColumn = TopPhenotypePerClusterPvalueColumn


### PR DESCRIPTION
## Summary

- Remove the full SusieRWorkflow susie_rscript input and run the container-provided /tmp/susie.R script.
- Stop exposing WindowSize on the full workflow; prep now uses CisDistance as the extraction window automatically.
- Remove the broad R-side prepared-window guard so expanded phenotype BEDs do not falsely fail in the full pipeline.
- Update the full workflow example input JSON and docs.

## Validation

- bash tools/validate_repo.sh